### PR TITLE
Added Checksum information to envelop

### DIFF
--- a/pkg/types/message_envelope.go
+++ b/pkg/types/message_envelope.go
@@ -21,12 +21,15 @@ import (
 )
 
 const (
+	checksum      = "payload-checksum"
 	correlationId = "correlation-id"
 	contentType   = "Content-Type"
 )
 
 // MessageEnvelope is the data structure for messages. It wraps the generic message payload with attributes.
 type MessageEnvelope struct {
+	// Checksum used to communicate to core-data that an Event message has been received via the message bus
+	Checksum string
 	// CorrelationID is an object id to identify the envelop
 	CorrelationID string
 	// Payload is byte representation of the data being transferred.
@@ -38,6 +41,7 @@ type MessageEnvelope struct {
 // NewMessageEnvelope creates a new MessageEnvelope for the specified payload with attributes from the specified context
 func NewMessageEnvelope(payload []byte, ctx context.Context) MessageEnvelope {
 	envelope := MessageEnvelope{
+		Checksum:      fromContext(ctx, checksum),
 		CorrelationID: fromContext(ctx, correlationId),
 		ContentType:   fromContext(ctx, contentType),
 		Payload:       payload,


### PR DESCRIPTION
This commit resolves issue #16

Added Event checksum identifier to message envelop.

Also added a new function for creating a message envelope with a checksum. I left the existing function as is to not break any other services that leverage that function.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>