### PR TITLE
Add minimum supported Go version 1.12 to go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/pebbe/zmq4 v1.0.0
 	github.com/stretchr/testify v1.3.0
 )
+
+go 1.12


### PR DESCRIPTION
Fix #34 

Locally, I upgraded to Go `1.12`, and tested it out via `Makefile`.