### PR TITLE
Add support for MQTT

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -1,4 +1,7 @@
 The following open source projects are referenced by go-mod-messaging:
 
+eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
+https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
+
 pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
 https://github.com/pebbe/zmq4/blob/master/LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # go-mod-messaging
-Messaging client library for use by Go implementation of EdgeX micro services.  This project contains the abstract Message Bus interface and an implementation for ZeroMQ.
+Messaging client library for use by Go implementation of EdgeX micro services.  This project contains the abstract Message Bus interface and an implementation for ZeroMQ, and MQTT.
 These interface functions connect, publish, subscribe and disconnect to/from the Message Bus.
 
 ### What is this repository for? ###
@@ -40,6 +40,45 @@ Host = 'localhost'
 Port = 5563
 Type = 'zero'
 Topic = 'events'
+```
+
+The MQTT client abstraction allows for the following additional configuration properties:
+
+- Username
+- Password
+- ClientId
+- Topic
+- Qos
+- KeepAlive
+- Retained
+- ConnectionPayload
+
+Which can be provided via TOML:
+
+```toml
+[MessageQueue]
+Protocol = 'tcp'
+Host = 'localhost'
+Port = 1883
+Type = 'mqtt'
+Topic = 'events'
+    [MessageQueue.Optional]
+    ClientId = 'MyClient'
+    Username = "MyUsername"
+    ...
+```
+Or programmatically in the Optional field of the MessageBusConfig struct. For example,
+
+```go
+types.MessageBusConfig{
+				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
+				Optional: map[string]string{
+					"ClientId":          "MyClientID",
+					"Username":          "MyUser",
+					"Password":          "MyPassword",
+					...
+				}}
+
 ```
 
 The following code snippets demonstrate how a service uses this messaging module to create a connection, send messages, and receive messages.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/edgexfoundry/go-mod-messaging
 
 require (
+	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/pebbe/zmq4 v1.0.0
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 )
 
 go 1.12

--- a/internal/pkg/mqtt/client.go
+++ b/internal/pkg/mqtt/client.go
@@ -1,0 +1,203 @@
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package mqtt
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// ClientCreator defines the function signature for creating an MQTT client.
+type ClientCreator func(config types.MessageBusConfig) (mqtt.Client, error)
+
+// MessageMarshaler defines the function signature for marshaling structs into []byte.
+type MessageMarshaler func(v interface{}) ([]byte, error)
+
+// MessageUnmarshaler defines the function signature for unmarshaling []byte into structs.
+type MessageUnmarshaler func(data []byte, v interface{}) error
+
+// Client facilitates communication to an MQTT server and provides functionality needed to send and receive MQTT
+// messages.
+type Client struct {
+	wrappedClient mqtt.Client
+	marshaler     MessageMarshaler
+	unmarshaler   MessageUnmarshaler
+}
+
+// NewMQTTClient constructs a new MQTT client based on the options provided.
+func NewMQTTClient(options types.MessageBusConfig) (Client, error) {
+	mqttClient, err := DefaultClientCreator()(options)
+	if err != nil {
+		return Client{}, err
+	}
+
+	return Client{
+		wrappedClient: mqttClient,
+		marshaler:     json.Marshal,
+		unmarshaler:   json.Unmarshal,
+	}, nil
+}
+
+// NewMQTTClientWithCreator constructs a new MQTT client based on the options and ClientCreator provided.
+func NewMQTTClientWithCreator(options types.MessageBusConfig, marshaler MessageMarshaler, unmarshaler MessageUnmarshaler, creator ClientCreator) (Client, error) {
+	wrappedClient, err := creator(options)
+	if err != nil {
+		return Client{}, err
+	}
+
+	return Client{
+		wrappedClient: wrappedClient,
+		marshaler:     marshaler,
+		unmarshaler:   unmarshaler,
+	}, nil
+}
+
+// Connect establishes a connection to a MQTT server.
+// This must be called before any other functionality provided by the Client.
+func (mc Client) Connect() error {
+	optionsReader := mc.wrappedClient.OptionsReader()
+
+	return getTokenError(
+		mc.wrappedClient.Connect(),
+		optionsReader.ConnectTimeout(),
+		ConnectOperation,
+		"Unable to connect")
+}
+
+// Publish sends a message to the connected MQTT server.
+func (mc Client) Publish(message types.MessageEnvelope, topic string) error {
+	marshaledMessage, err := mc.marshaler(message)
+	if err != nil {
+		return NewOperationErr(PublishOperation, err.Error())
+	}
+
+	optionsReader := mc.wrappedClient.OptionsReader()
+	return getTokenError(
+		mc.wrappedClient.Publish(
+			topic,
+			optionsReader.WillQos(),
+			optionsReader.WillRetained(),
+			marshaledMessage),
+		optionsReader.ConnectTimeout(),
+		PublishOperation,
+		"Unable to publish message")
+
+}
+
+// Subscribe creates a subscription for the specified topics.
+func (mc Client) Subscribe(topics []types.TopicChannel, messageErrors chan error) error {
+	optionsReader := mc.wrappedClient.OptionsReader()
+
+	for _, topic := range topics {
+		err := getTokenError(
+			mc.wrappedClient.Subscribe(
+				topic.Topic,
+				optionsReader.WillQos(),
+				newMessageHandler(mc.unmarshaler, topic.Messages, messageErrors)),
+			optionsReader.ConnectTimeout(),
+			SubscribeOperation,
+			"Failed to create subscription")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Disconnect closes the connection to the connected MQTT server.
+func (mc Client) Disconnect() error {
+
+	// Specify a wait time equal to the write timeout so that we allow other any queued processing to complete before
+	// disconnecting.
+	optionsReader := mc.wrappedClient.OptionsReader()
+	mc.wrappedClient.Disconnect(uint(optionsReader.ConnectTimeout() * time.Millisecond))
+
+	return nil
+}
+
+// DefaultClientCreator returns a default function for creating MQTT clients.
+func DefaultClientCreator() ClientCreator {
+	return func(options types.MessageBusConfig) (mqtt.Client, error) {
+		clientConfiguration, err := CreateMQTTClientConfiguration(options)
+		if err != nil {
+			return nil, err
+		}
+
+		return mqtt.NewClient(createClientOptions(clientConfiguration)), nil
+	}
+}
+
+// newMessageHandler creates a function which meets the criteria for a MessageHandler and propagates the received
+// messages to the proper channel.
+func newMessageHandler(
+	unmarshaler MessageUnmarshaler,
+	messageChannel chan<- types.MessageEnvelope,
+	errorChannel chan<- error) mqtt.MessageHandler {
+
+	return func(client mqtt.Client, message mqtt.Message) {
+		var messageEnvelope types.MessageEnvelope
+		payload := message.Payload()
+		err := unmarshaler(payload, &messageEnvelope)
+		if err != nil {
+			errorChannel <- err
+		}
+
+		messageChannel <- messageEnvelope
+	}
+}
+
+// getTokenError determines if a Token is in an errored state and if so returns the proper error message. Otherwise,
+// nil.
+//
+// NOTE the paho.mqtt.golang's recommended way for handling errors do not cover all cases. During manual verification
+// with an MQTT server, it was observed that the Token.Error() was sometimes nil even when a token.WaitTimeout(...)
+// returned false(indicating the operation has timed-out). Therefore, there are some additional checks that need to
+// take place to ensure the error message is returned if it is present. One example scenario, if you attempt to connect
+// without providing a ClientID.
+func getTokenError(token mqtt.Token, timeout time.Duration, operation string, defaultTimeoutMessage string) error {
+	hasTimedOut := !token.WaitTimeout(timeout)
+
+	if hasTimedOut && token.Error() != nil {
+		return NewTimeoutError(operation, token.Error().Error())
+	}
+
+	if hasTimedOut && token.Error() == nil {
+		return NewTimeoutError(operation, defaultTimeoutMessage)
+	}
+
+	if token.Error() != nil {
+		return NewOperationErr(operation, token.Error().Error())
+	}
+
+	return nil
+}
+
+// createClientOptions constructs mqtt.Client options from an MQTTClientConfig.
+func createClientOptions(clientConfiguration MQTTClientConfig) *mqtt.ClientOptions {
+	clientOptions := mqtt.NewClientOptions()
+	clientOptions.AddBroker(clientConfiguration.BrokerURL)
+	clientOptions.SetUsername(clientConfiguration.Username)
+	clientOptions.SetPassword(clientConfiguration.Password)
+	clientOptions.SetClientID(clientConfiguration.ClientId)
+	clientOptions.SetWill(clientConfiguration.Topic, clientConfiguration.ConnectionPayload, byte(clientConfiguration.Qos), clientConfiguration.Retained)
+	clientOptions.SetKeepAlive(time.Duration(clientConfiguration.KeepAlive) * time.Second)
+
+	return clientOptions
+}

--- a/internal/pkg/mqtt/client_integration_test.go
+++ b/internal/pkg/mqtt/client_integration_test.go
@@ -1,0 +1,122 @@
+// +build integration
+
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+/**
+ * This test file contains integration tests for the MQTT Client. These integration tests are disabled by default as
+ * they require additional external resources to be executed properly. These tests are enabled by providing the
+ * `integration` tag when running the tests. For example 'go test ./... -tags=integration`.
+ *
+ * This is a list of the requirements necessary to run the tests in this file:
+ * - MQTT server with no authentication required by clients.
+ * - The MQTT server URL set as the environment variable MQTT_SERVER_TEST. Otherwise the default 'tcp://localhost:1833
+ *  will be used
+ */
+
+package mqtt
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+)
+
+const (
+	MQTTURLEnvName = "MQTT_SERVER_TEST"
+	DefaultMQTTURL = "tcp://localhost:1883"
+)
+
+// TestIntegrationWithMQTTServer end-to-end test of the MQTT client with a MQTT server.
+func TestIntegrationWithMQTTServer(t *testing.T) {
+	mqttURL := os.Getenv(MQTTURLEnvName)
+	if mqttURL == "" {
+		mqttURL = DefaultMQTTURL
+	}
+
+	urlMQTT, err := url.Parse(mqttURL)
+	if err != nil {
+		t.Error("Failed to create URL:" + err.Error())
+		return
+	}
+
+	port, err := strconv.ParseInt(urlMQTT.Port(), 10, 0)
+	if err != nil {
+		fmt.Errorf("Unable to parse the port:%s ", err.Error())
+	}
+	configOptions := types.MessageBusConfig{
+		PublishHost: types.HostInfo{
+			Host:     urlMQTT.Hostname(),
+			Port:     int(port),
+			Protocol: urlMQTT.Scheme,
+		},
+		Optional: map[string]string{
+			ClientId:          "integration-test-client",
+			Username:          "",
+			Password:          "",
+			Topic:             "test1",
+			Qos:               "0",
+			KeepAlive:         "5",
+			Retained:          "false",
+			ConnectionPayload: "",
+		},
+	}
+
+	client, err := NewMQTTClient(configOptions)
+	if err != nil {
+		t.Error("Failed to create MQTT client: " + err.Error())
+	}
+
+	err = client.Connect()
+	defer client.Disconnect()
+	if err != nil {
+		t.Error("Failed to connect:" + err.Error())
+		return
+	}
+
+	channel := make(chan types.MessageEnvelope)
+	topics := []types.TopicChannel{{
+		Topic:    "test1",
+		Messages: channel,
+	}}
+
+	err = client.Subscribe(topics, make(chan error))
+	if err != nil {
+		t.Error("Failed to create subscription: " + err.Error())
+		return
+	}
+
+	expectedMessage := types.MessageEnvelope{
+		Checksum:      "123",
+		CorrelationID: "456",
+		Payload:       []byte("Testing the MQTT client"),
+		ContentType:   "application/text",
+	}
+
+	err = client.Publish(expectedMessage, "test1")
+	if err != nil {
+		t.Error("Failed to publish: " + err.Error())
+		return
+	}
+
+	actualMessage := <-channel
+	if !reflect.DeepEqual(expectedMessage, actualMessage) {
+		t.Errorf("Expected message of: %v , but got: %v", expectedMessage, actualMessage)
+	}
+}

--- a/internal/pkg/mqtt/client_options.go
+++ b/internal/pkg/mqtt/client_options.go
@@ -1,0 +1,139 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package mqtt
+
+import (
+	"fmt"
+	"math/rand"
+	"net/url"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+)
+
+const (
+	// Constants for configuration properties provided via the MessageBusConfig's Optional field.
+	Username          = "Username"
+	Password          = "Password"
+	ClientId          = "ClientId"
+	Topic             = "Topic"
+	Qos               = "Qos"
+	KeepAlive         = "KeepAlive"
+	Retained          = "Retained"
+	ConnectionPayload = "ConnectionPayload"
+)
+
+// MQTTClientConfig contains all the configurations for the MQTT client.
+type MQTTClientConfig struct {
+	BrokerURL string
+	MQTTClientOptions
+}
+
+// ConnectionOptions contains the connection configurations for the MQTT client.
+//
+// NOTE: The connection properties resides in its own struct in order to avoid the property being loaded in via
+//  reflection during the load process.
+type ConnectionOptions struct {
+	BrokerURL string
+}
+
+// MQTTClientOptions contains the client options which are loaded via reflection
+type MQTTClientOptions struct {
+	Username          string
+	Password          string
+	ClientId          string
+	Topic             string
+	Qos               int
+	KeepAlive         int
+	Retained          bool
+	ConnectionPayload string
+}
+
+// CreateMQTTClientConfiguration constructs a MQTTClientConfig based on the provided MessageBusConfig.
+func CreateMQTTClientConfiguration(messageBusConfig types.MessageBusConfig) (MQTTClientConfig, error) {
+	brokerUrl := messageBusConfig.PublishHost.GetHostURL()
+	_, err := url.Parse(brokerUrl)
+	if err != nil {
+		return MQTTClientConfig{}, err
+	}
+
+	mqttClientOptions := CreateMQTTClientOptionsWithDefaults()
+	err = load(messageBusConfig.Optional, &mqttClientOptions)
+	if err != nil {
+		return MQTTClientConfig{}, err
+	}
+
+	return MQTTClientConfig{
+		BrokerURL:         brokerUrl,
+		MQTTClientOptions: mqttClientOptions,
+	}, nil
+}
+
+// load by reflect to check map key and then fetch the value.
+// This function ignores properties that have not been provided from the source. Therefore it is recommended to provide
+// a destination struct with reasonable defaults.
+//
+// NOTE: This logic was borrowed from device-mqtt-go and some additional logic was added to accommodate more types.
+// https://github.com/edgexfoundry/device-mqtt-go/blob/a0d50c6e03a7f7dcb28f133885c803ffad3ec502/internal/driver/config.go#L74-L101
+func load(config map[string]string, des interface{}) error {
+	val := reflect.ValueOf(des).Elem()
+	for i := 0; i < val.NumField(); i++ {
+		typeField := val.Type().Field(i)
+		valueField := val.Field(i)
+
+		val, ok := config[typeField.Name]
+		if !ok {
+			// Ignore the property if the value is not provided
+			continue
+		}
+
+		switch valueField.Kind() {
+		case reflect.Int:
+			intVal, err := strconv.Atoi(val)
+			if err != nil {
+				return err
+			}
+			valueField.SetInt(int64(intVal))
+		case reflect.String:
+			valueField.SetString(val)
+		case reflect.Bool:
+			boolVal, err := strconv.ParseBool(val)
+			if err != nil {
+				return err
+			}
+			valueField.SetBool(boolVal)
+		default:
+			return fmt.Errorf("none supported value type %v ,%v", valueField.Kind(), typeField.Name)
+		}
+	}
+	return nil
+}
+
+func CreateMQTTClientOptionsWithDefaults() MQTTClientOptions {
+	randomClientId := strconv.Itoa(rand.New(rand.NewSource(time.Now().UnixNano())).Intn(100000))
+	return MQTTClientOptions{
+		Username: "",
+		Password: "",
+		// Client ID is required or else can cause unexpected errors. This was observed with Eclipse's Mosquito MQTT server.
+		ClientId:          randomClientId,
+		Topic:             "",
+		Qos:               0,
+		KeepAlive:         0,
+		Retained:          false,
+		ConnectionPayload: "",
+	}
+}

--- a/internal/pkg/mqtt/client_options_test.go
+++ b/internal/pkg/mqtt/client_options_test.go
@@ -1,0 +1,167 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package mqtt
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+)
+
+func TestCreateMQTTClientConfiguration(t *testing.T) {
+	type args struct {
+		messageBusConfig types.MessageBusConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    MQTTClientConfig
+		wantErr bool
+	}{
+		{
+			"Successfully load all configurations",
+			args{types.MessageBusConfig{
+				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
+				Optional: map[string]string{
+					"Username":          "TestUser",
+					"Password":          "TestPassword",
+					"ClientId":          "TestClientID",
+					"Topic":             "TestTopic",
+					"Qos":               "1",
+					"KeepAlive":         "3",
+					"Retained":          "true",
+					"ConnectionPayload": "TestConnectionPayload",
+				}}},
+			MQTTClientConfig{
+				BrokerURL: "tcp://example.com:9090",
+				MQTTClientOptions: MQTTClientOptions{
+					Username:          "TestUser",
+					Password:          "TestPassword",
+					ClientId:          "TestClientID",
+					Topic:             "TestTopic",
+					Qos:               1,
+					KeepAlive:         3,
+					Retained:          true,
+					ConnectionPayload: "TestConnectionPayload",
+				},
+			},
+			false,
+		},
+		{
+			"Does not over write host configuration with optional properties",
+			args{types.MessageBusConfig{
+				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
+				Optional: map[string]string{
+					"BrokerURL":         "http://fail.edu",
+					"Username":          "TestUser",
+					"Password":          "TestPassword",
+					"ClientId":          "TestClientID",
+					"Topic":             "TestTopic",
+					"Qos":               "1",
+					"KeepAlive":         "3",
+					"Retained":          "true",
+					"ConnectionPayload": "TestConnectionPayload",
+				}}},
+			MQTTClientConfig{
+				BrokerURL: "tcp://example.com:9090",
+				MQTTClientOptions: MQTTClientOptions{
+					Username:          "TestUser",
+					Password:          "TestPassword",
+					ClientId:          "TestClientID",
+					Topic:             "TestTopic",
+					Qos:               1,
+					KeepAlive:         3,
+					Retained:          true,
+					ConnectionPayload: "TestConnectionPayload",
+				}},
+			false,
+		},
+		{
+			"Invalid URL",
+			args{types.MessageBusConfig{
+				PublishHost: types.HostInfo{Host: "   ", Port: 999999999999, Protocol: "    "},
+				Optional: map[string]string{
+					// Other valid configurations
+					"ClientId": "TestClientID",
+				}}},
+			MQTTClientConfig{},
+			true,
+		},
+		{
+			"Invalid Int",
+			args{types.MessageBusConfig{
+				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
+				Optional: map[string]string{
+					"KeepAlive": "abc",
+					// Other valid configurations
+				}}},
+			MQTTClientConfig{},
+			true,
+		},
+		{
+			"Invalid Bool",
+			args{types.MessageBusConfig{
+				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
+				Optional: map[string]string{
+					"Retained": "abc",
+				}}},
+			MQTTClientConfig{},
+			true,
+		},
+		{
+			"Unknown configuration",
+			args{types.MessageBusConfig{
+				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
+				Optional: map[string]string{
+					"Username":          "TestUser",
+					"Password":          "TestPassword",
+					"ClientId":          "TestClientID",
+					"Topic":             "TestTopic",
+					"Qos":               "1",
+					"KeepAlive":         "3",
+					"Retained":          "true",
+					"ConnectionPayload": "TestConnectionPayload",
+					"Unknown config":    "Something random",
+				}}},
+			MQTTClientConfig{
+				BrokerURL: "tcp://example.com:9090",
+				MQTTClientOptions: MQTTClientOptions{
+					Username:          "TestUser",
+					Password:          "TestPassword",
+					ClientId:          "TestClientID",
+					Topic:             "TestTopic",
+					Qos:               1,
+					KeepAlive:         3,
+					Retained:          true,
+					ConnectionPayload: "TestConnectionPayload",
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateMQTTClientConfiguration(tt.args.messageBusConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateMQTTClientConfiguration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateMQTTClientConfiguration() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/mqtt/client_test.go
+++ b/internal/pkg/mqtt/client_test.go
@@ -1,0 +1,602 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package mqtt
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+)
+
+// TestMessageBusConfig defines a simple configuration used for testing successful options parsing.
+var TestMessageBusConfig = types.MessageBusConfig{
+	PublishHost: types.HostInfo{Host: "localhost"},
+	Optional: map[string]string{
+		"Schema":            "tcp",
+		"Host":              "example.com",
+		"Port":              "9090",
+		"Username":          "TestUser",
+		"Password":          "TestPassword",
+		"ClientId":          "TestClientID",
+		"Topic":             "TestTopic",
+		"Qos":               "1",
+		"KeepAlive":         "3",
+		"Retained":          "true",
+		"ConnectionPayload": "TestConnectionPayload",
+	},
+}
+
+// MockToken implements Token and gives control over the information returned to the caller of the various
+// Client methods, such as Connect.
+type MockToken struct {
+	waitTimeOut bool
+	err         error
+}
+
+// SuccessfulMockToken creates a MockToken which returns data indicating a successfully completed operation.
+func SuccessfulMockToken() MockToken {
+	return MockToken{
+		waitTimeOut: true,
+		err:         nil,
+	}
+}
+
+// TimeoutNoErrorMockToken creates a MockToken which returns data indicating a timeout has occurred and does not provide
+// an error with additional information.
+func TimeoutNoErrorMockToken() MockToken {
+	return MockToken{
+		waitTimeOut: false,
+		err:         nil,
+	}
+}
+
+// TimeoutWithErrorMockToken creates a MockToken which returns data indicating a timeout has occurred and provides an
+// error with additional information.
+func TimeoutWithErrorMockToken() MockToken {
+	return MockToken{
+		waitTimeOut: false,
+		err:         errors.New("timeout while trying to complete operation"),
+	}
+}
+
+// ErrorMockToken creates a MockToken which returns data indicating an error has occurred by providing an error.
+func ErrorMockToken() MockToken {
+	return MockToken{
+		waitTimeOut: true,
+		err:         errors.New("operation failed"),
+	}
+}
+
+func (mt MockToken) WaitTimeout(time.Duration) bool {
+	return mt.waitTimeOut
+}
+
+func (mt MockToken) Error() error {
+	return mt.err
+}
+
+// MockMQTTClient implements the Client interface and allows for control over the returned data when invoking it's
+// methods.
+type MockMQTTClient struct {
+	subscriptions map[string]mqtt.MessageHandler
+	// MockTokens used to control the returned values for the respective functions.
+	connect   MockToken
+	publish   MockToken
+	subscribe MockToken
+}
+
+func (mc MockMQTTClient) Connect() mqtt.Token {
+	return &mc.connect
+}
+
+func (mc MockMQTTClient) Publish(topic string, _ byte, _ bool, message interface{}) mqtt.Token {
+	handler, ok := mc.subscriptions[topic]
+	if !ok {
+		return &mc.publish
+	}
+
+	go handler(mc, MockMessage{payload: message.([]byte)})
+	return &mc.publish
+}
+
+func (mc MockMQTTClient) Subscribe(topic string, _ byte, handler mqtt.MessageHandler) mqtt.Token {
+	mc.subscriptions[topic] = handler
+	return &mc.subscribe
+}
+
+func (mc MockMQTTClient) Disconnect(uint) {
+	// No implementation required.
+}
+
+func (mt MockToken) Wait() bool {
+	panic("function not expected to be invoked")
+}
+
+func (MockMQTTClient) IsConnected() bool {
+	panic("function not expected to be invoked")
+}
+
+func (MockMQTTClient) IsConnectionOpen() bool {
+	panic("function not expected to be invoked")
+}
+
+func (MockMQTTClient) SubscribeMultiple(map[string]byte, mqtt.MessageHandler) mqtt.Token {
+	panic("function not expected to be invoked")
+}
+
+func (MockMQTTClient) Unsubscribe(...string) mqtt.Token {
+	panic("function not expected to be invoked")
+}
+
+func (MockMQTTClient) AddRoute(string, mqtt.MessageHandler) {
+	panic("function not expected to be invoked")
+}
+
+func (MockMQTTClient) OptionsReader() mqtt.ClientOptionsReader {
+	return mqtt.NewClient(mqtt.NewClientOptions()).OptionsReader()
+
+}
+
+// MockMessage implements the Message interface and allows for control over the returned data when a MessageHandler is
+// invoked.
+type MockMessage struct {
+	payload []byte
+}
+
+func (mm MockMessage) Payload() []byte {
+	return mm.payload
+}
+
+func (MockMessage) Duplicate() bool {
+	panic("function not expected to be invoked")
+}
+
+func (MockMessage) Qos() byte {
+	panic("function not expected to be invoked")
+}
+
+func (MockMessage) Retained() bool {
+	panic("function not expected to be invoked")
+}
+
+func (MockMessage) Topic() string {
+	panic("function not expected to be invoked")
+}
+
+func (MockMessage) MessageID() uint16 {
+	panic("function not expected to be invoked")
+}
+
+func (MockMessage) Ack() {
+	panic("function not expected to be invoked")
+}
+
+// mockClientCreator higher-order function which creates a function that constructs a MockMQTTClient
+func mockClientCreator(connect MockToken, publish MockToken, subscribe MockToken) ClientCreator {
+	return func(config types.MessageBusConfig) (mqtt.Client, error) {
+		return MockMQTTClient{
+			connect:       connect,
+			publish:       publish,
+			subscribe:     subscribe,
+			subscriptions: make(map[string]mqtt.MessageHandler),
+		}, nil
+
+	}
+}
+
+func TestInvalidClientOptions(t *testing.T) {
+	invalidOptions := types.MessageBusConfig{PublishHost: types.HostInfo{
+		Host:     "    ",
+		Port:     0,
+		Protocol: "    ",
+	}}
+
+	_, err := NewMQTTClient(invalidOptions)
+	if err == nil {
+		t.Error("Expected error but did not observe one")
+		return
+	}
+}
+
+func TestInvalidClientOptionsWithCreator(t *testing.T) {
+	invalidOptions := types.MessageBusConfig{PublishHost: types.HostInfo{
+		Host:     "    ",
+		Port:     0,
+		Protocol: "    ",
+	}}
+
+	_, err := NewMQTTClientWithCreator(invalidOptions, json.Marshal, json.Unmarshal, DefaultClientCreator())
+	if err == nil {
+		t.Error("Expected error but did not observe one")
+		return
+	}
+}
+
+func TestClient_Connect(t *testing.T) {
+	tests := []struct {
+		name         string
+		connectToken MockToken
+		expectError  bool
+		errorType    error
+	}{
+		{
+			"Successful connection",
+			SuccessfulMockToken(),
+			false,
+			nil,
+		},
+		{
+			"Connect timeout with error",
+			TimeoutWithErrorMockToken(),
+			true,
+			TimeoutErr{},
+		},
+		{
+			"Connect timeout without error",
+			TimeoutNoErrorMockToken(),
+			true,
+			TimeoutErr{},
+		},
+		{
+			"Connect error",
+			ErrorMockToken(),
+			true,
+			OperationErr{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			client, _ := NewMQTTClientWithCreator(
+				TestMessageBusConfig,
+				json.Marshal,
+				json.Unmarshal,
+				mockClientCreator(test.connectToken, MockToken{}, MockToken{}))
+
+			err := client.Connect()
+			if !test.expectError && err != nil {
+				t.Errorf("Did not expect error but observed: %s", err.Error())
+				return
+			}
+
+			if test.expectError && err == nil {
+				t.Error("Expected error but did not observe one")
+				return
+			}
+
+			if test.expectError && test.errorType != nil {
+				eet := reflect.TypeOf(test.errorType)
+				aet := reflect.TypeOf(err)
+				if !aet.AssignableTo(eet) {
+					t.Errorf("Expected error of type %v, but got an error of type %v", eet, aet)
+				}
+			}
+
+		})
+	}
+}
+
+func TestClient_Publish(t *testing.T) {
+	tests := []struct {
+		name         string
+		publishToken MockToken
+		message      types.MessageEnvelope
+		marshaler    MessageMarshaler
+		expectError  bool
+		errorType    error
+	}{
+		{
+			"Successful publish",
+			SuccessfulMockToken(),
+			types.MessageEnvelope{},
+			json.Marshal,
+			false,
+			nil,
+		},
+
+		{
+			"Marshal error",
+			SuccessfulMockToken(),
+			types.MessageEnvelope{},
+			mockMarshalerError,
+			true,
+			OperationErr{},
+		},
+		{
+			"Publish error",
+			ErrorMockToken(),
+			types.MessageEnvelope{},
+			json.Marshal,
+			true,
+			OperationErr{},
+		},
+		{
+			"Publish timeout with error",
+			TimeoutWithErrorMockToken(),
+			types.MessageEnvelope{},
+			json.Marshal,
+			true,
+			TimeoutErr{},
+		},
+		{
+			"Publish timeout without error",
+			TimeoutNoErrorMockToken(),
+			types.MessageEnvelope{},
+			json.Marshal,
+			true,
+			TimeoutErr{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, _ := NewMQTTClientWithCreator(
+				TestMessageBusConfig,
+				test.marshaler,
+				json.Unmarshal,
+				mockClientCreator(MockToken{}, test.publishToken, MockToken{}))
+
+			err := client.Publish(test.message, "test-topic")
+			if !test.expectError && err != nil {
+				t.Errorf("Did not expect error but observed: %s", err.Error())
+				return
+			}
+
+			if test.expectError && err == nil {
+				t.Error("Expected error but did not observe one")
+				return
+			}
+
+			if test.expectError && test.errorType != nil {
+				eet := reflect.TypeOf(test.errorType)
+				aet := reflect.TypeOf(err)
+				if !aet.AssignableTo(eet) {
+					t.Errorf("Expected error of type %v, but got an error of type %v", eet, aet)
+				}
+			}
+		})
+	}
+}
+
+func TestClient_Subscribe(t *testing.T) {
+	tests := []struct {
+		name           string
+		subscribeToken MockToken
+		topics         []string
+		expectError    bool
+		errorType      error
+	}{
+		{
+			"Successful subscription",
+			SuccessfulMockToken(),
+			[]string{"topic"},
+			false,
+			nil,
+		},
+		{
+			"Successful subscription multiple topics",
+			SuccessfulMockToken(),
+			[]string{"topic1", "topic2", "topic3"},
+			false,
+			nil,
+		},
+		{
+			"Subscribe error",
+			ErrorMockToken(),
+			[]string{"topic1", "topic2"},
+			true,
+			OperationErr{},
+		},
+		{
+			"Subscribe timeout with error",
+			TimeoutWithErrorMockToken(),
+			[]string{"topic1", "topic2"},
+			true,
+			TimeoutErr{},
+		},
+		{
+			"Subscribe timeout without error",
+			TimeoutNoErrorMockToken(),
+			[]string{"topic1", "topic2"},
+			true,
+			TimeoutErr{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, _ := NewMQTTClientWithCreator(
+				TestMessageBusConfig,
+				json.Marshal,
+				json.Unmarshal,
+				mockClientCreator(MockToken{}, MockToken{}, test.subscribeToken))
+			topicChannels := make([]types.TopicChannel, 0)
+			for _, topic := range test.topics {
+				topicChannels = append(topicChannels, types.TopicChannel{
+					Topic:    topic,
+					Messages: make(chan types.MessageEnvelope),
+				})
+			}
+
+			err := client.Subscribe(topicChannels, make(chan error))
+			if !test.expectError && err != nil {
+				t.Errorf("Did not expect error but observed: %s", err.Error())
+				return
+			}
+
+			if test.expectError && err == nil {
+				t.Error("Expected error but did not observe one")
+				return
+			}
+
+			if test.expectError && test.errorType != nil {
+				eet := reflect.TypeOf(test.errorType)
+				aet := reflect.TypeOf(err)
+				if !aet.AssignableTo(eet) {
+					t.Errorf("Expected error of type %v, but got an error of type %v", eet, aet)
+				}
+			}
+		})
+	}
+}
+
+func TestClient_Disconnect(t *testing.T) {
+	client, _ := NewMQTTClient(TestMessageBusConfig)
+	err := client.Disconnect()
+	if err != nil {
+		t.Errorf("Disconnect is not expected to return an errors: %s", err.Error())
+	}
+
+	err = client.Disconnect()
+	if err != nil {
+		t.Errorf("Disconnect is not expected to return an error if not connected: %s", err.Error())
+	}
+
+}
+
+func TestSubscriptionMessageHandler(t *testing.T) {
+	client, _ := NewMQTTClientWithCreator(
+		TestMessageBusConfig,
+		json.Marshal,
+		json.Unmarshal,
+		mockClientCreator(SuccessfulMockToken(), SuccessfulMockToken(), SuccessfulMockToken()))
+
+	topic1Channel := make(chan types.MessageEnvelope)
+	topic2Channel := make(chan types.MessageEnvelope)
+	topicChannels := []types.TopicChannel{{
+		Topic:    "test1",
+		Messages: topic1Channel,
+	}, {
+		Topic:    "test2",
+		Messages: topic2Channel,
+	}}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go receiveMessage(wg, topic1Channel, 1)
+	go receiveMessage(wg, topic2Channel, 1)
+	err := client.Subscribe(topicChannels, make(chan error))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	err = client.Publish(types.MessageEnvelope{
+		Checksum:      "123",
+		CorrelationID: "456",
+		Payload:       []byte("Simple payload"),
+		ContentType:   "application/json",
+	}, "test1")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	err = client.Publish(types.MessageEnvelope{
+		Checksum:      "789",
+		CorrelationID: "000",
+		Payload:       []byte("Another simple payload"),
+		ContentType:   "application/json",
+	}, "test2")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	wg.Wait()
+}
+
+func TestSubscriptionMessageHandlerError(t *testing.T) {
+	client, _ := NewMQTTClientWithCreator(TestMessageBusConfig,
+		json.Marshal,
+		mockUnmarshalerError,
+		mockClientCreator(MockToken{
+			waitTimeOut: true,
+			err:         nil,
+		}, MockToken{
+			waitTimeOut: true,
+			err:         nil,
+		}, MockToken{
+			waitTimeOut: true,
+			err:         nil,
+		}))
+
+	topicChannels := []types.TopicChannel{{
+		Topic:    "test1",
+		Messages: make(chan types.MessageEnvelope),
+	}, {
+		Topic:    "test2",
+		Messages: make(chan types.MessageEnvelope),
+	}}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	errorChannel := make(chan error)
+	go receiveError(wg, errorChannel, 1)
+	err := client.Subscribe(topicChannels, errorChannel)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	err = client.Publish(types.MessageEnvelope{
+		Checksum:      "123",
+		CorrelationID: "456",
+		Payload:       []byte("Simple payload"),
+		ContentType:   "application/json",
+	}, "test1")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	err = client.Publish(types.MessageEnvelope{
+		Checksum:      "789",
+		CorrelationID: "000",
+		Payload:       []byte("Another simple payload"),
+		ContentType:   "application/json",
+	}, "test2")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	wg.Wait()
+}
+
+// mockMarshalerError returns an error when marshaling is attempted.
+func mockMarshalerError(interface{}) ([]byte, error) {
+	return nil, errors.New("marshal error")
+}
+
+// mockUnmarshalerError returns an error when unmarshaling is attempted.
+func mockUnmarshalerError([]byte, interface{}) error {
+	return errors.New("unmarshal error")
+}
+
+// receiveMessage polls the provided channel until the expected number of messages has been received.
+func receiveMessage(group *sync.WaitGroup, messageChannel <-chan types.MessageEnvelope, expectedMessages int) {
+	for counter := 0; counter < expectedMessages; counter++ {
+		<-messageChannel
+	}
+	group.Done()
+}
+
+// receiveError polls the provided channel until the expected number of errors has been received.
+func receiveError(group *sync.WaitGroup, errorChannel <-chan error, expectedMessages int) {
+	for counter := 0; counter < expectedMessages; counter++ {
+		<-errorChannel
+	}
+	group.Done()
+}

--- a/internal/pkg/mqtt/errors.go
+++ b/internal/pkg/mqtt/errors.go
@@ -1,0 +1,62 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package mqtt
+
+import (
+	"fmt"
+)
+
+const (
+	// Different Client operations.
+	PublishOperation   = "Publish"
+	SubscribeOperation = "Subscribe"
+	ConnectOperation   = "Connect"
+)
+
+// TimeoutErr defines an error representing operations which have not completed and surpassed the allowed wait time.
+type TimeoutErr struct {
+	operation string
+	message   string
+}
+
+func (te TimeoutErr) Error() string {
+	return fmt.Sprintf("Timeout occured while performing a '%s' operation: %s", te.operation, te.message)
+}
+
+// NewTimeoutError creates a new TimeoutErr.
+func NewTimeoutError(operation string, message string) TimeoutErr {
+	return TimeoutErr{
+		operation: operation,
+		message:   message,
+	}
+}
+
+// OperationErr defines an error representing operations which have failed.
+type OperationErr struct {
+	operation string
+	message   string
+}
+
+func (oe OperationErr) Error() string {
+	return fmt.Sprintf("An error occured while performing a '%s' operation: %s", oe.operation, oe.message)
+}
+
+// NewOperationErr creates a new OperationErr
+func NewOperationErr(operation string, message string) OperationErr {
+	return OperationErr{
+		operation: operation,
+		message:   message,
+	}
+}

--- a/messaging/factory.go
+++ b/messaging/factory.go
@@ -20,14 +20,17 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
-
+	"github.com/edgexfoundry/go-mod-messaging/internal/pkg/mqtt"
 	"github.com/edgexfoundry/go-mod-messaging/internal/pkg/zeromq"
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 )
 
 const (
 	// ZeroMQ messaging implementation
 	ZeroMQ = "zero"
+
+	// MQTT messaging implementation
+	MQTT = "mqtt"
 )
 
 // NewMessageClient is a factory function to instantiate different message client depending on
@@ -41,6 +44,8 @@ func NewMessageClient(msgConfig types.MessageBusConfig) (MessageClient, error) {
 	switch lowerMsgType := strings.ToLower(msgConfig.Type); lowerMsgType {
 	case ZeroMQ:
 		return zeromq.NewZeroMqClient(msgConfig)
+	case MQTT:
+		return mqtt.NewMQTTClient(msgConfig)
 	default:
 		return nil, fmt.Errorf("unknown message type '%s' requested", msgConfig.Type)
 	}

--- a/messaging/factory_test.go
+++ b/messaging/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,9 +34,29 @@ var msgConfig = types.MessageBusConfig{
 
 func TestNewMessageClientZeroMq(t *testing.T) {
 
-	msgConfig.Type = "zero"
-
+	msgConfig.Type = ZeroMQ
 	_, err := NewMessageClient(msgConfig)
+
+	if assert.NoError(t, err, "New Message client failed: ", err) == false {
+		t.Fatal()
+	}
+}
+
+func TestNewMessageClientMQTT(t *testing.T) {
+	messageBusConfig := msgConfig
+	messageBusConfig.Type = MQTT
+	messageBusConfig.Optional = map[string]string{
+		"Username":          "TestUser",
+		"Password":          "TestPassword",
+		"ClientId":          "TestClientID",
+		"Topic":             "TestTopic",
+		"Qos":               "1",
+		"KeepAlive":         "3",
+		"Retained":          "true",
+		"ConnectionPayload": "TestConnectionPayload",
+	}
+
+	_, err := NewMessageClient(messageBusConfig)
 
 	if assert.NoError(t, err, "New Message client failed: ", err) == false {
 		t.Fatal()


### PR DESCRIPTION
Fix #36

Create implementation of Client which communicates with an MQTT server
to provide the necessary functionality.

Add unit tests for new MQTT client

Update Attribution.txt to include the newly import library
'eclipse/paho.mqtt.golang'.

Add integration tests which are disabled by default and are enable via
Go's test tag integration(See documentation in client_integration_test
file). The integration tests use a MQTT server to test the MQTT clients
functionality since there were functional gaps missing in the unit tests
which are better handled with integration tests.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>