### PR TITLE
Add TLS Support For MQTT Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ The MQTT client abstraction allows for the following additional configuration pr
 - KeepAlive
 - Retained
 - ConnectionPayload
+- CertFile
+- KeyFile
+- CertPEMBlock
+- KeyPEMBlock
+- SkipCertVerify
 
 Which can be provided via TOML:
 

--- a/internal/pkg/errors.go
+++ b/internal/pkg/errors.go
@@ -1,0 +1,45 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package pkg
+
+import "fmt"
+
+// CertificateErr represents an error associated with interacting with a Certificate.
+type CertificateErr struct {
+	description string
+}
+
+func (ce CertificateErr) Error() string {
+	return fmt.Sprintf("Unable to process certificate properties: %s", ce.description)
+}
+
+// NewCertificateErr constructs a new CertificateErr
+func NewCertificateErr(message string) CertificateErr {
+	return CertificateErr{description: message}
+}
+
+// BrokerURLErr represents an error associated parsing a broker's URL.
+type BrokerURLErr struct {
+	description string
+}
+
+func (bue BrokerURLErr) Error() string {
+	return fmt.Sprintf("Unable to process broker URL: %s", bue.description)
+}
+
+// NewBrokerURLErr constructs a new BrokerURLErr
+func NewBrokerURLErr(description string) BrokerURLErr {
+	return BrokerURLErr{description: description}
+}

--- a/internal/pkg/mqtt/client_integration_test.go
+++ b/internal/pkg/mqtt/client_integration_test.go
@@ -35,6 +35,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-messaging/messaging/mqtt"
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 )
 
@@ -67,14 +68,14 @@ func TestIntegrationWithMQTTServer(t *testing.T) {
 			Protocol: urlMQTT.Scheme,
 		},
 		Optional: map[string]string{
-			ClientId:          "integration-test-client",
-			Username:          "",
-			Password:          "",
-			Topic:             "test1",
-			Qos:               "0",
-			KeepAlive:         "5",
-			Retained:          "false",
-			ConnectionPayload: "",
+			mqtt.ClientId:          "integration-test-client",
+			mqtt.Username:          "",
+			mqtt.Password:          "",
+			mqtt.Topic:             "test1",
+			mqtt.Qos:               "0",
+			mqtt.KeepAlive:         "5",
+			mqtt.Retained:          "false",
+			mqtt.ConnectionPayload: "",
 		},
 	}
 

--- a/internal/pkg/mqtt/client_test.go
+++ b/internal/pkg/mqtt/client_test.go
@@ -15,6 +15,7 @@
 package mqtt
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -22,27 +23,64 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eclipse/paho.mqtt.golang"
-
+	"github.com/edgexfoundry/go-mod-messaging/messaging/mqtt"
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/assert"
 )
+
+var OptionalPropertiesNoTls = map[string]string{
+	mqtt.Username:          "TestUser",
+	mqtt.Password:          "TestPassword",
+	mqtt.ClientId:          "TestClientID",
+	mqtt.Topic:             "TestTopic",
+	mqtt.Qos:               "1",
+	mqtt.KeepAlive:         "3",
+	mqtt.Retained:          "true",
+	mqtt.ConnectionPayload: "TestConnectionPayload",
+}
+
+var OptionalPropertiesCertCreate = map[string]string{
+	mqtt.Username:          "TestUser",
+	mqtt.Password:          "TestPassword",
+	mqtt.ClientId:          "TestClientID",
+	mqtt.Topic:             "TestTopic",
+	mqtt.Qos:               "1",
+	mqtt.KeepAlive:         "3",
+	mqtt.Retained:          "true",
+	mqtt.ConnectionPayload: "TestConnectionPayload",
+	mqtt.CertPEMBlock:      "CertBytes",
+	mqtt.KeyPEMBlock:       "KeyBytes",
+}
+
+var OptionalPropertiesCertLoad = map[string]string{
+	mqtt.Username:          "TestUser",
+	mqtt.Password:          "TestPassword",
+	mqtt.ClientId:          "TestClientID",
+	mqtt.Topic:             "TestTopic",
+	mqtt.Qos:               "1",
+	mqtt.KeepAlive:         "3",
+	mqtt.Retained:          "true",
+	mqtt.ConnectionPayload: "TestConnectionPayload",
+	mqtt.CertFile:          "./cert",
+	mqtt.KeyFile:           "./key",
+}
+var TlsHostInfo = types.HostInfo{Host: "localhost", Protocol: "tls"}
 
 // TestMessageBusConfig defines a simple configuration used for testing successful options parsing.
 var TestMessageBusConfig = types.MessageBusConfig{
-	PublishHost: types.HostInfo{Host: "localhost"},
-	Optional: map[string]string{
-		"Schema":            "tcp",
-		"Host":              "example.com",
-		"Port":              "9090",
-		"Username":          "TestUser",
-		"Password":          "TestPassword",
-		"ClientId":          "TestClientID",
-		"Topic":             "TestTopic",
-		"Qos":               "1",
-		"KeepAlive":         "3",
-		"Retained":          "true",
-		"ConnectionPayload": "TestConnectionPayload",
-	},
+	PublishHost: types.HostInfo{Host: "localhost", Protocol: "tcp"},
+	Optional:    OptionalPropertiesNoTls,
+}
+var TestMessageBusConfigTlsCreate = types.MessageBusConfig{
+	PublishHost: types.HostInfo{Host: "localhost", Protocol: "tls"},
+	Optional:    OptionalPropertiesCertCreate,
+}
+
+var TestMessageBusConfigTlsLoad = types.MessageBusConfig{
+	PublishHost: types.HostInfo{Host: "localhost", Protocol: "tls"},
+	Optional:    OptionalPropertiesCertLoad,
 }
 
 // MockToken implements Token and gives control over the information returned to the caller of the various
@@ -97,18 +135,18 @@ func (mt MockToken) Error() error {
 // MockMQTTClient implements the Client interface and allows for control over the returned data when invoking it's
 // methods.
 type MockMQTTClient struct {
-	subscriptions map[string]mqtt.MessageHandler
+	subscriptions map[string]pahomqtt.MessageHandler
 	// MockTokens used to control the returned values for the respective functions.
 	connect   MockToken
 	publish   MockToken
 	subscribe MockToken
 }
 
-func (mc MockMQTTClient) Connect() mqtt.Token {
+func (mc MockMQTTClient) Connect() pahomqtt.Token {
 	return &mc.connect
 }
 
-func (mc MockMQTTClient) Publish(topic string, _ byte, _ bool, message interface{}) mqtt.Token {
+func (mc MockMQTTClient) Publish(topic string, _ byte, _ bool, message interface{}) pahomqtt.Token {
 	handler, ok := mc.subscriptions[topic]
 	if !ok {
 		return &mc.publish
@@ -118,7 +156,7 @@ func (mc MockMQTTClient) Publish(topic string, _ byte, _ bool, message interface
 	return &mc.publish
 }
 
-func (mc MockMQTTClient) Subscribe(topic string, _ byte, handler mqtt.MessageHandler) mqtt.Token {
+func (mc MockMQTTClient) Subscribe(topic string, _ byte, handler pahomqtt.MessageHandler) pahomqtt.Token {
 	mc.subscriptions[topic] = handler
 	return &mc.subscribe
 }
@@ -139,20 +177,20 @@ func (MockMQTTClient) IsConnectionOpen() bool {
 	panic("function not expected to be invoked")
 }
 
-func (MockMQTTClient) SubscribeMultiple(map[string]byte, mqtt.MessageHandler) mqtt.Token {
+func (MockMQTTClient) SubscribeMultiple(map[string]byte, pahomqtt.MessageHandler) pahomqtt.Token {
 	panic("function not expected to be invoked")
 }
 
-func (MockMQTTClient) Unsubscribe(...string) mqtt.Token {
+func (MockMQTTClient) Unsubscribe(...string) pahomqtt.Token {
 	panic("function not expected to be invoked")
 }
 
-func (MockMQTTClient) AddRoute(string, mqtt.MessageHandler) {
+func (MockMQTTClient) AddRoute(string, pahomqtt.MessageHandler) {
 	panic("function not expected to be invoked")
 }
 
-func (MockMQTTClient) OptionsReader() mqtt.ClientOptionsReader {
-	return mqtt.NewClient(mqtt.NewClientOptions()).OptionsReader()
+func (MockMQTTClient) OptionsReader() pahomqtt.ClientOptionsReader {
+	return pahomqtt.NewClient(pahomqtt.NewClientOptions()).OptionsReader()
 
 }
 
@@ -192,12 +230,12 @@ func (MockMessage) Ack() {
 
 // mockClientCreator higher-order function which creates a function that constructs a MockMQTTClient
 func mockClientCreator(connect MockToken, publish MockToken, subscribe MockToken) ClientCreator {
-	return func(config types.MessageBusConfig) (mqtt.Client, error) {
+	return func(config types.MessageBusConfig) (pahomqtt.Client, error) {
 		return MockMQTTClient{
 			connect:       connect,
 			publish:       publish,
 			subscribe:     subscribe,
-			subscriptions: make(map[string]mqtt.MessageHandler),
+			subscriptions: make(map[string]pahomqtt.MessageHandler),
 		}, nil
 
 	}
@@ -215,6 +253,206 @@ func TestInvalidClientOptions(t *testing.T) {
 		t.Error("Expected error but did not observe one")
 		return
 	}
+}
+
+func TestInvalidTlsOptions(t *testing.T) {
+	options := types.MessageBusConfig{
+		PublishHost: TlsHostInfo,
+		Optional: map[string]string{
+			"CertFile": "./does-not-exist",
+			"KeyFile":  "./does-not-exist",
+		},
+	}
+	_, err := NewMQTTClient(options)
+	if err == nil {
+		t.Error("Expected error but did not observe one")
+		return
+	}
+}
+
+func TestClientCreatorTLS(t *testing.T) {
+	tests := []struct {
+		name            string
+		hostConfig      types.HostInfo
+		optionalConfig  map[string]string
+		certCreator     X509KeyPairCreator
+		certLoader      X509KeyLoader
+		expectError     bool
+		expectTLSConfig bool
+	}{
+		{
+			name:       "Create TLS Config from PEM Block",
+			hostConfig: TlsHostInfo,
+			optionalConfig: map[string]string{
+				mqtt.CertPEMBlock: "CertPEMBlock",
+				mqtt.KeyPEMBlock:  "KeyPEMBlock",
+			},
+			certCreator:     mockCertCreator(nil),
+			certLoader:      mockCertLoader(nil),
+			expectError:     false,
+			expectTLSConfig: true,
+		},
+		{
+			name: "Skip TLS Config from PEM Block for non-supported TLS protocols",
+			hostConfig: types.HostInfo{
+				Host:     "localhost",
+				Protocol: "tcp",
+			},
+			optionalConfig: map[string]string{
+				mqtt.CertPEMBlock: "CertPEMBlock",
+				mqtt.KeyPEMBlock:  "KeyPEMBlock",
+			},
+			certCreator:     mockCertCreator(nil),
+			certLoader:      mockCertLoader(nil),
+			expectError:     false,
+			expectTLSConfig: false,
+		},
+		{
+			name:       "Fail Create TLS Config from PEM File",
+			hostConfig: TlsHostInfo,
+			optionalConfig: map[string]string{
+				mqtt.CertPEMBlock: "CertPEMBlock",
+				mqtt.KeyPEMBlock:  "KeyPEMBlock",
+			},
+			certCreator:     mockCertCreator(errors.New("test error")),
+			certLoader:      mockCertLoader(nil),
+			expectError:     true,
+			expectTLSConfig: false,
+		},
+		{
+			name:       "Load TLS Config from Cert File",
+			hostConfig: TlsHostInfo,
+			optionalConfig: map[string]string{
+				mqtt.CertFile: "./cert",
+				mqtt.KeyFile:  "./key",
+			},
+			certCreator:     mockCertCreator(nil),
+			certLoader:      mockCertLoader(nil),
+			expectError:     false,
+			expectTLSConfig: true,
+		},
+		{
+			name:       "Skip Load TLS Config from Cert File for un-supported protocols",
+			hostConfig: types.HostInfo{Host: "localhost", Protocol: "tcp"},
+			optionalConfig: map[string]string{
+				mqtt.CertFile: "./cert",
+				mqtt.KeyFile:  "./key",
+			},
+			certCreator:     mockCertCreator(nil),
+			certLoader:      mockCertLoader(nil),
+			expectError:     false,
+			expectTLSConfig: false,
+		},
+		{
+			name:       "Fail Load TLS Config from Cert File",
+			hostConfig: TlsHostInfo,
+			optionalConfig: map[string]string{
+				mqtt.CertFile: "./cert",
+				mqtt.KeyFile:  "./key",
+			},
+			certCreator:     mockCertCreator(nil),
+			certLoader:      mockCertLoader(errors.New("test error")),
+			expectError:     true,
+			expectTLSConfig: false,
+		},
+		{
+			name:       "Fail Load TLS Config For Invalid Options",
+			hostConfig: TlsHostInfo,
+			optionalConfig: map[string]string{
+				mqtt.Qos: "abc",
+			},
+			certCreator:     mockCertCreator(nil),
+			certLoader:      mockCertLoader(errors.New("test error")),
+			expectError:     true,
+			expectTLSConfig: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := NewMQTTClientWithCreator(
+				types.MessageBusConfig{
+					PublishHost: test.hostConfig,
+					Optional:    test.optionalConfig,
+				},
+				json.Marshal,
+				json.Unmarshal,
+				ClientCreatorWithCertLoader(test.certCreator, test.certLoader))
+
+			if test.expectError && err == nil {
+				t.Error("Expected error but did not observe one")
+				return
+			}
+
+			if test.expectError && err != nil {
+				return
+			}
+
+			if err != nil {
+				clientOptions := client.wrappedClient.OptionsReader()
+				tlsConfig := clientOptions.TLSConfig()
+
+				if test.expectTLSConfig {
+					assert.NotNil(t, tlsConfig, "Failed to configure TLS for underlying client")
+				} else {
+					assert.Nil(t, tlsConfig, "Expected TLS configuration to be not be provided.")
+				}
+			}
+		})
+	}
+}
+
+func TestClientCreatorTlsLoader(t *testing.T) {
+	client, err := NewMQTTClientWithCreator(
+		TestMessageBusConfigTlsLoad,
+		json.Marshal,
+		json.Unmarshal,
+		ClientCreatorWithCertLoader(mockCertCreator(nil), mockCertLoader(nil)))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	clientOptions := client.wrappedClient.OptionsReader()
+	tlsConfig := clientOptions.TLSConfig()
+	assert.NotNil(t, tlsConfig, "Failed to configure TLS for underlying client")
+}
+
+func TestClientCreatorTlsLoadError(t *testing.T) {
+	_, err := NewMQTTClientWithCreator(
+		TestMessageBusConfigTlsLoad,
+		json.Marshal,
+		json.Unmarshal,
+		ClientCreatorWithCertLoader(mockCertCreator(nil), mockCertLoader(errors.New("test error"))))
+
+	assert.Error(t, err, "Expected error for invalid CertFile and KeyFile file locations")
+}
+
+func TestClientCreatorTlsCreator(t *testing.T) {
+	client, err := NewMQTTClientWithCreator(
+		TestMessageBusConfigTlsCreate,
+		json.Marshal,
+		json.Unmarshal,
+		ClientCreatorWithCertLoader(mockCertCreator(nil), mockCertLoader(nil)))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	clientOptions := client.wrappedClient.OptionsReader()
+	tlsConfig := clientOptions.TLSConfig()
+	assert.NotNil(t, tlsConfig, "Failed to configure TLS for underlying client")
+}
+
+func TestClientCreatorTlsCreatorError(t *testing.T) {
+	_, err := NewMQTTClientWithCreator(
+		TestMessageBusConfigTlsCreate,
+		json.Marshal,
+		json.Unmarshal,
+		ClientCreatorWithCertLoader(mockCertCreator(errors.New("test error")), mockCertLoader(nil)))
+
+	assert.Error(t, err, "Expected error for invalid CertFile and KeyFile file locations")
 }
 
 func TestInvalidClientOptionsWithCreator(t *testing.T) {
@@ -599,4 +837,16 @@ func receiveError(group *sync.WaitGroup, errorChannel <-chan error, expectedMess
 		<-errorChannel
 	}
 	group.Done()
+}
+
+func mockCertCreator(returnError error) X509KeyPairCreator {
+	return func(certPEMBlock []byte, keyPEMBlock []byte) (certificate tls.Certificate, err error) {
+		return tls.Certificate{}, returnError
+	}
+}
+
+func mockCertLoader(returnError error) X509KeyLoader {
+	return func(certFile string, keyFile string) (certificate tls.Certificate, err error) {
+		return tls.Certificate{}, returnError
+	}
 }

--- a/messaging/mqtt/constants.go
+++ b/messaging/mqtt/constants.go
@@ -1,0 +1,40 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// Package mqtt provides functionality useful for interacting with the MQTT client implementation.
+package mqtt
+
+const (
+	// Constants for configuration properties provided via the MessageBusConfig's Optional field.
+
+	// Client identifier configurations
+	Username = "Username"
+	Password = "Password"
+	ClientId = "ClientId"
+
+	// Connection configuration names
+	Topic             = "Topic"
+	Qos               = "Qos"
+	KeepAlive         = "KeepAlive"
+	Retained          = "Retained"
+	ConnectionPayload = "ConnectionPayload"
+	AutoReconnect     = "AutoReconnect"
+
+	// TLS configuration names
+	SkipCertVerify = "SkipCertVerify"
+	CertFile       = "CertFile"
+	KeyFile        = "KeyFile"
+	KeyPEMBlock    = "KeyPEMBlock"
+	CertPEMBlock   = "CertPEMBlock"
+)


### PR DESCRIPTION
Fix #41

Update MQTT client, client options, and constructors to allow for
configuration of TLS communication.

Update tests to cover newly added functionality.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>