### PR TITLE
Add TLS Support For MQTT Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ The MQTT client abstraction allows for the following additional configuration pr
 - KeepAlive
 - Retained
 - ConnectionPayload
+- CertFile
+- KeyFile
+- CertPEMBlock
+- KeyPEMBlock
+- SkipCertVerify
 
 Which can be provided via TOML:
 
@@ -80,6 +85,9 @@ types.MessageBusConfig{
 				}}
 
 ```
+
+**NOTE**  
+ The best way to construct the `Optional` map is to use the provided [mqttOptionalConfigurationBuilder](./messaging/mqtt/configuration.go) struct which gives the additional benefit of ensuring the expected types for each property is correct.
 
 The following code snippets demonstrate how a service uses this messaging module to create a connection, send messages, and receive messages.
 

--- a/internal/pkg/errors.go
+++ b/internal/pkg/errors.go
@@ -1,0 +1,45 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package pkg
+
+import "fmt"
+
+// CertificateErr represents an error associated with interacting with a Certificate.
+type CertificateErr struct {
+	description string
+}
+
+func (ce CertificateErr) Error() string {
+	return fmt.Sprintf("Unable to process certificate properties: %s", ce.description)
+}
+
+// NewCertificateErr constructs a new CertificateErr
+func NewCertificateErr(message string) CertificateErr {
+	return CertificateErr{description: message}
+}
+
+// BrokerURLErr represents an error associated parsing a broker's URL.
+type BrokerURLErr struct {
+	description string
+}
+
+func (bue BrokerURLErr) Error() string {
+	return fmt.Sprintf("Unable to process broker URL: %s", bue.description)
+}
+
+// NewBrokerURLErr constructs a new BrokerURLErr
+func NewBrokerURLErr(description string) BrokerURLErr {
+	return BrokerURLErr{description: description}
+}

--- a/internal/pkg/mqtt/client.go
+++ b/internal/pkg/mqtt/client.go
@@ -15,16 +15,28 @@
 package mqtt
 
 import (
+	"crypto/tls"
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-messaging/internal/pkg"
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
+var TlsSchemes = []string{"tcps", "ssl", "tls"}
+
 // ClientCreator defines the function signature for creating an MQTT client.
 type ClientCreator func(config types.MessageBusConfig) (mqtt.Client, error)
+
+// X509KeyPairCreator defines the function signature for creating a tls.Certificate based on PEM encoding.
+type X509KeyPairCreator func(certPEMBlock []byte, keyPEMBlock []byte) (tls.Certificate, error)
+
+// X509KeyLoader defines a function signature for loading a tls.Certificate from cert and key files.
+type X509KeyLoader func(certFile string, keyFile string) (tls.Certificate, error)
 
 // MessageMarshaler defines the function signature for marshaling structs into []byte.
 type MessageMarshaler func(v interface{}) ([]byte, error)
@@ -55,7 +67,12 @@ func NewMQTTClient(options types.MessageBusConfig) (Client, error) {
 }
 
 // NewMQTTClientWithCreator constructs a new MQTT client based on the options and ClientCreator provided.
-func NewMQTTClientWithCreator(options types.MessageBusConfig, marshaler MessageMarshaler, unmarshaler MessageUnmarshaler, creator ClientCreator) (Client, error) {
+func NewMQTTClientWithCreator(
+	options types.MessageBusConfig,
+	marshaler MessageMarshaler,
+	unmarshaler MessageUnmarshaler,
+	creator ClientCreator) (Client, error) {
+
 	wrappedClient, err := creator(options)
 	if err != nil {
 		return Client{}, err
@@ -71,6 +88,11 @@ func NewMQTTClientWithCreator(options types.MessageBusConfig, marshaler MessageM
 // Connect establishes a connection to a MQTT server.
 // This must be called before any other functionality provided by the Client.
 func (mc Client) Connect() error {
+	// Avoid reconnecting if already connected.
+	if mc.wrappedClient.IsConnected() {
+		return nil
+	}
+
 	optionsReader := mc.wrappedClient.OptionsReader()
 
 	return getTokenError(
@@ -140,7 +162,30 @@ func DefaultClientCreator() ClientCreator {
 			return nil, err
 		}
 
-		return mqtt.NewClient(createClientOptions(clientConfiguration)), nil
+		clientOptions, err := createClientOptions(clientConfiguration, tls.X509KeyPair, tls.LoadX509KeyPair)
+		if err != nil {
+			return nil, err
+		}
+
+		return mqtt.NewClient(clientOptions), nil
+	}
+}
+
+// ClientCreatorWithCertLoader creates a ClientCreator which leverages the specified cert creator and loader when
+// creating an MQTT client.
+func ClientCreatorWithCertLoader(certCreator X509KeyPairCreator, certLoader X509KeyLoader) ClientCreator {
+	return func(options types.MessageBusConfig) (mqtt.Client, error) {
+		clientConfiguration, err := CreateMQTTClientConfiguration(options)
+		if err != nil {
+			return nil, err
+		}
+
+		clientOptions, err := createClientOptions(clientConfiguration, certCreator, certLoader)
+		if err != nil {
+			return nil, err
+		}
+
+		return mqtt.NewClient(clientOptions), nil
 	}
 }
 
@@ -190,14 +235,89 @@ func getTokenError(token mqtt.Token, timeout time.Duration, operation string, de
 }
 
 // createClientOptions constructs mqtt.Client options from an MQTTClientConfig.
-func createClientOptions(clientConfiguration MQTTClientConfig) *mqtt.ClientOptions {
+func createClientOptions(
+	clientConfiguration MQTTClientConfig,
+	certCreator X509KeyPairCreator,
+	certLoader X509KeyLoader) (*mqtt.ClientOptions, error) {
+
 	clientOptions := mqtt.NewClientOptions()
 	clientOptions.AddBroker(clientConfiguration.BrokerURL)
 	clientOptions.SetUsername(clientConfiguration.Username)
 	clientOptions.SetPassword(clientConfiguration.Password)
 	clientOptions.SetClientID(clientConfiguration.ClientId)
-	clientOptions.SetWill(clientConfiguration.Topic, clientConfiguration.ConnectionPayload, byte(clientConfiguration.Qos), clientConfiguration.Retained)
 	clientOptions.SetKeepAlive(time.Duration(clientConfiguration.KeepAlive) * time.Second)
+	clientOptions.SetAutoReconnect(clientConfiguration.AutoReconnect)
+	clientOptions.SetConnectTimeout(time.Duration(clientConfiguration.ConnectTimeout) * time.Second)
+	tlsConfiguration, err := generateTLSForClientClientOptions(clientConfiguration, certCreator, certLoader)
+	if err != nil {
+		return clientOptions, err
+	}
 
-	return clientOptions
+	clientOptions.SetTLSConfig(tlsConfiguration)
+
+	return clientOptions, nil
+}
+
+// generateTLSForClientClientOptions creates a tls.Config which can be used when configuring the underlying MQTT client.
+// If TLS is not needed then nil will be returned which can be used to signal no TLS is needed to the MQTT client.
+func generateTLSForClientClientOptions(
+	clientConfiguration MQTTClientConfig,
+	certCreator X509KeyPairCreator,
+	certLoader X509KeyLoader) (*tls.Config, error) {
+
+	// Nothing to do if the CertFile, KeyFile, CertPEMBlock, and KeyPEMBlock properties are not provided.
+	if len(clientConfiguration.CertFile) <= 0 && len(clientConfiguration.KeyFile) <= 0 &&
+		len(clientConfiguration.CertPEMBlock) <= 0 && len(clientConfiguration.KeyPEMBlock) <= 0 {
+		return nil, nil
+	}
+
+	brokerURL, err := url.Parse(clientConfiguration.BrokerURL)
+	if err != nil {
+		return nil, pkg.NewBrokerURLErr(fmt.Sprintf("Failed to parse broker: %v", err))
+	}
+
+	for _, scheme := range TlsSchemes {
+		if brokerURL.Scheme != scheme {
+			continue
+		}
+
+		cert, err := generateCertificate(clientConfiguration, certCreator, certLoader)
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConfig := &tls.Config{
+			ClientCAs:          nil,
+			InsecureSkipVerify: clientConfiguration.SkipCertVerify,
+			Certificates:       []tls.Certificate{cert},
+		}
+
+		return tlsConfig, nil
+	}
+
+	// The scheme being used either does not require TLS or is not supported with this configuration setup.
+	return nil, nil
+}
+
+// generateCertificate creates a x509 certificate by either loading it from an existing cert and key files, or creates
+// a cert and key from the provided PEM bytes.
+func generateCertificate(
+	clientConfiguration MQTTClientConfig,
+	certCreator X509KeyPairCreator,
+	certLoader X509KeyLoader) (tls.Certificate, error) {
+
+	var cert tls.Certificate
+	var err error
+
+	if clientConfiguration.KeyPEMBlock != "" && clientConfiguration.CertPEMBlock != "" {
+		cert, err = certCreator([]byte(clientConfiguration.CertPEMBlock), []byte(clientConfiguration.KeyPEMBlock))
+	} else {
+		cert, err = certLoader(clientConfiguration.CertFile, clientConfiguration.KeyFile)
+	}
+
+	if err != nil {
+		return cert, pkg.NewCertificateErr(fmt.Sprintf("Failed loading x509 data: %v", err))
+	}
+
+	return cert, nil
 }

--- a/internal/pkg/mqtt/client_options_test.go
+++ b/internal/pkg/mqtt/client_options_test.go
@@ -15,9 +15,12 @@
 package mqtt
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/go-mod-messaging/messaging/mqtt"
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 )
 
@@ -36,26 +39,24 @@ func TestCreateMQTTClientConfiguration(t *testing.T) {
 			args{types.MessageBusConfig{
 				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
 				Optional: map[string]string{
-					"Username":          "TestUser",
-					"Password":          "TestPassword",
-					"ClientId":          "TestClientID",
-					"Topic":             "TestTopic",
-					"Qos":               "1",
-					"KeepAlive":         "3",
-					"Retained":          "true",
-					"ConnectionPayload": "TestConnectionPayload",
+					mqtt.Username:       "TestUser",
+					mqtt.Password:       "TestPassword",
+					mqtt.ClientId:       "TestClientID",
+					mqtt.Qos:            "1",
+					mqtt.KeepAlive:      "3",
+					mqtt.Retained:       "true",
+					mqtt.ConnectTimeout: "7",
 				}}},
 			MQTTClientConfig{
 				BrokerURL: "tcp://example.com:9090",
 				MQTTClientOptions: MQTTClientOptions{
-					Username:          "TestUser",
-					Password:          "TestPassword",
-					ClientId:          "TestClientID",
-					Topic:             "TestTopic",
-					Qos:               1,
-					KeepAlive:         3,
-					Retained:          true,
-					ConnectionPayload: "TestConnectionPayload",
+					Username:       "TestUser",
+					Password:       "TestPassword",
+					ClientId:       "TestClientID",
+					Qos:            1,
+					KeepAlive:      3,
+					Retained:       true,
+					ConnectTimeout: 7,
 				},
 			},
 			false,
@@ -65,27 +66,24 @@ func TestCreateMQTTClientConfiguration(t *testing.T) {
 			args{types.MessageBusConfig{
 				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
 				Optional: map[string]string{
-					"BrokerURL":         "http://fail.edu",
-					"Username":          "TestUser",
-					"Password":          "TestPassword",
-					"ClientId":          "TestClientID",
-					"Topic":             "TestTopic",
-					"Qos":               "1",
-					"KeepAlive":         "3",
-					"Retained":          "true",
-					"ConnectionPayload": "TestConnectionPayload",
+					mqtt.Username:       "TestUser",
+					mqtt.Password:       "TestPassword",
+					mqtt.ClientId:       "TestClientID",
+					mqtt.Qos:            "1",
+					mqtt.KeepAlive:      "3",
+					mqtt.Retained:       "true",
+					mqtt.ConnectTimeout: "7",
 				}}},
 			MQTTClientConfig{
 				BrokerURL: "tcp://example.com:9090",
 				MQTTClientOptions: MQTTClientOptions{
-					Username:          "TestUser",
-					Password:          "TestPassword",
-					ClientId:          "TestClientID",
-					Topic:             "TestTopic",
-					Qos:               1,
-					KeepAlive:         3,
-					Retained:          true,
-					ConnectionPayload: "TestConnectionPayload",
+					Username:       "TestUser",
+					Password:       "TestPassword",
+					ClientId:       "TestClientID",
+					Qos:            1,
+					KeepAlive:      3,
+					Retained:       true,
+					ConnectTimeout: 7,
 				}},
 			false,
 		},
@@ -126,27 +124,25 @@ func TestCreateMQTTClientConfiguration(t *testing.T) {
 			args{types.MessageBusConfig{
 				PublishHost: types.HostInfo{Host: "example.com", Port: 9090, Protocol: "tcp"},
 				Optional: map[string]string{
-					"Username":          "TestUser",
-					"Password":          "TestPassword",
-					"ClientId":          "TestClientID",
-					"Topic":             "TestTopic",
-					"Qos":               "1",
-					"KeepAlive":         "3",
-					"Retained":          "true",
-					"ConnectionPayload": "TestConnectionPayload",
+					mqtt.Username:       "TestUser",
+					mqtt.Password:       "TestPassword",
+					mqtt.ClientId:       "TestClientID",
+					mqtt.Qos:            "1",
+					mqtt.KeepAlive:      "3",
+					mqtt.Retained:       "true",
+					mqtt.ConnectTimeout: "7",
 					"Unknown config":    "Something random",
 				}}},
 			MQTTClientConfig{
 				BrokerURL: "tcp://example.com:9090",
 				MQTTClientOptions: MQTTClientOptions{
-					Username:          "TestUser",
-					Password:          "TestPassword",
-					ClientId:          "TestClientID",
-					Topic:             "TestTopic",
-					Qos:               1,
-					KeepAlive:         3,
-					Retained:          true,
-					ConnectionPayload: "TestConnectionPayload",
+					Username:       "TestUser",
+					Password:       "TestPassword",
+					ClientId:       "TestClientID",
+					Qos:            1,
+					KeepAlive:      3,
+					Retained:       true,
+					ConnectTimeout: 7,
 				},
 			},
 			false,
@@ -155,13 +151,14 @@ func TestCreateMQTTClientConfiguration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := CreateMQTTClientConfiguration(tt.args.messageBusConfig)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateMQTTClientConfiguration() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err, "CreateMQTTClientConfiguration() error = %v, wantErr %v", err, tt.wantErr)
+				return // End test for expected errors
+			} else {
+				require.NoError(t, err)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CreateMQTTClientConfiguration() got = %v, want %v", got, tt.want)
-			}
+
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/messaging/mqtt/configuration.go
+++ b/messaging/mqtt/configuration.go
@@ -1,0 +1,120 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// Package mqtt provides additional functionality to aid in configuring a MQTT client.
+package mqtt
+
+import "strconv"
+
+// mqttOptionalConfigurationBuilder encapsulates the optional configuration data following the builder pattern. Updating
+// values are done via the exported builder methods and the final map can be obtained by calling the Build method.
+//
+// This is the recommended way to create optional parameters for an MQTT client since the underlying structure is a map
+// of string : string which can introduce issues with type casting. The builder methods for this struct are created to
+// accept the expected types to reduce the chance of incorrect type casting.
+type mqttOptionalConfigurationBuilder struct {
+	options map[string]string
+}
+
+// NewMQTTOptionalConfigurationBuilder constructs a new mqttOptionalConfigurationBuilder.
+func NewMQTTOptionalConfigurationBuilder() *mqttOptionalConfigurationBuilder {
+	return &mqttOptionalConfigurationBuilder{
+		options: make(map[string]string),
+	}
+}
+
+// Build constructs the optional configuration map based which can be used when creating an MQTT client.
+func (mocb *mqttOptionalConfigurationBuilder) Build() map[string]string {
+	return mocb.options
+}
+
+// AutoReconnect sets the autoReconnect configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) AutoReconnect(autoReconnect bool) *mqttOptionalConfigurationBuilder {
+	mocb.options[AutoReconnect] = strconv.FormatBool(autoReconnect)
+	return mocb
+}
+
+// CertFile sets the certFile configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) CertFile(certFile string) *mqttOptionalConfigurationBuilder {
+	mocb.options[CertFile] = certFile
+	return mocb
+}
+
+// CertPEMBlock sets the certPEMBlock configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) CertPEMBlock(certPEMBlock string) *mqttOptionalConfigurationBuilder {
+	mocb.options[CertPEMBlock] = certPEMBlock
+	return mocb
+}
+
+// ClientID sets the clientID configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) ClientID(clientID string) *mqttOptionalConfigurationBuilder {
+	mocb.options[ClientId] = clientID
+	return mocb
+}
+
+// ConnectTimeout sets the connectionTimeout configuration property in seconds and returns the builder struct for
+// further updates.
+func (mocb *mqttOptionalConfigurationBuilder) ConnectTimeout(connectionTimeout int) *mqttOptionalConfigurationBuilder {
+	mocb.options[ConnectTimeout] = strconv.Itoa(connectionTimeout)
+	return mocb
+}
+
+// KeepAlive sets the keepAlive duration in seconds configuration property and returns the builder struct for further
+// updates.
+func (mocb *mqttOptionalConfigurationBuilder) KeepAlive(keepAlive int) *mqttOptionalConfigurationBuilder {
+	mocb.options[KeepAlive] = strconv.Itoa(keepAlive)
+	return mocb
+}
+
+// KeyPEMBlock sets the keyPEMBlock configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) KeyPEMBlock(keyPEMBlock string) *mqttOptionalConfigurationBuilder {
+	mocb.options[KeyPEMBlock] = keyPEMBlock
+	return mocb
+}
+
+// KeyFile sets the fileLocation configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) KeyFile(fileLocation string) *mqttOptionalConfigurationBuilder {
+	mocb.options[KeyFile] = fileLocation
+	return mocb
+}
+
+// Password sets the password configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) Password(password string) *mqttOptionalConfigurationBuilder {
+	mocb.options[Password] = password
+	return mocb
+}
+
+// Qos sets the qos configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) Qos(qos int) *mqttOptionalConfigurationBuilder {
+	mocb.options[Qos] = strconv.Itoa(qos)
+	return mocb
+}
+
+// Retained sets the retained configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) Retained(retained bool) *mqttOptionalConfigurationBuilder {
+	mocb.options[Retained] = strconv.FormatBool(retained)
+	return mocb
+}
+
+// SkipCertVerify sets the skipCertVerify configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) SkipCertVerify(skipCertVerify bool) *mqttOptionalConfigurationBuilder {
+	mocb.options[SkipCertVerify] = strconv.FormatBool(skipCertVerify)
+	return mocb
+}
+
+// Username sets the username configuration property and returns the builder struct for further updates.
+func (mocb *mqttOptionalConfigurationBuilder) Username(username string) *mqttOptionalConfigurationBuilder {
+	mocb.options[Username] = username
+	return mocb
+}

--- a/messaging/mqtt/configuration_test.go
+++ b/messaging/mqtt/configuration_test.go
@@ -1,0 +1,171 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package mqtt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/go-mod-messaging/internal/pkg/mqtt"
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+)
+
+func TestBuilderMethods(t *testing.T) {
+	tests := []struct {
+		name           string
+		builder        *mqttOptionalConfigurationBuilder
+		expectedValues map[string]string
+	}{
+		{
+			name:           "AutoReconnect",
+			builder:        NewMQTTOptionalConfigurationBuilder().AutoReconnect(true),
+			expectedValues: map[string]string{AutoReconnect: "true"},
+		},
+		{
+			name:           "CertFile",
+			builder:        NewMQTTOptionalConfigurationBuilder().CertFile("/path/to/some/cert"),
+			expectedValues: map[string]string{CertFile: "/path/to/some/cert"},
+		},
+		{
+			name:           "CertPEMBlock",
+			builder:        NewMQTTOptionalConfigurationBuilder().CertPEMBlock("/path/to/some/cert"),
+			expectedValues: map[string]string{CertPEMBlock: "/path/to/some/cert"},
+		},
+		{
+			name:           "ClientID",
+			builder:        NewMQTTOptionalConfigurationBuilder().ClientID("ProvidedClientID"),
+			expectedValues: map[string]string{ClientId: "ProvidedClientID"},
+		},
+		{
+			name:           "ConnectTimeout",
+			builder:        NewMQTTOptionalConfigurationBuilder().ConnectTimeout(99),
+			expectedValues: map[string]string{ConnectTimeout: "99"},
+		},
+		{
+			name:           "KeepAlive",
+			builder:        NewMQTTOptionalConfigurationBuilder().KeepAlive(99),
+			expectedValues: map[string]string{KeepAlive: "99"},
+		},
+		{
+			name:           "KeyPEMBlock",
+			builder:        NewMQTTOptionalConfigurationBuilder().KeyPEMBlock("ProvidedKeyPEMBlock"),
+			expectedValues: map[string]string{KeyPEMBlock: "ProvidedKeyPEMBlock"},
+		},
+		{
+			name:           "KeyFile",
+			builder:        NewMQTTOptionalConfigurationBuilder().KeyFile("ProvidedKeyFile"),
+			expectedValues: map[string]string{KeyFile: "ProvidedKeyFile"},
+		},
+		{
+			name:           "Password",
+			builder:        NewMQTTOptionalConfigurationBuilder().Password("ProvidedPassword"),
+			expectedValues: map[string]string{Password: "ProvidedPassword"},
+		},
+		{
+			name:           "Qos",
+			builder:        NewMQTTOptionalConfigurationBuilder().Qos(1),
+			expectedValues: map[string]string{Qos: "1"},
+		},
+		{
+			name:           "Retained",
+			builder:        NewMQTTOptionalConfigurationBuilder().Retained(true),
+			expectedValues: map[string]string{Retained: "true"},
+		},
+		{
+			name:           "SkipCertVerify",
+			builder:        NewMQTTOptionalConfigurationBuilder().SkipCertVerify(true),
+			expectedValues: map[string]string{SkipCertVerify: "true"},
+		},
+		{
+			name:           "Username",
+			builder:        NewMQTTOptionalConfigurationBuilder().Username("ProvidedUsername"),
+			expectedValues: map[string]string{Username: "ProvidedUsername"},
+		},
+		{
+			name: "Multiple Properties of Different Types",
+			builder: NewMQTTOptionalConfigurationBuilder().
+				Username("ProvidedUsername").
+				SkipCertVerify(true).
+				KeepAlive(99),
+			expectedValues: map[string]string{Username: "ProvidedUsername", SkipCertVerify: "true", KeepAlive: "99"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observedConfig := test.builder.Build()
+
+			for key, value := range test.expectedValues {
+				assert.Equal(t, value, observedConfig[key])
+			}
+
+		})
+	}
+}
+
+func TestClientOptionsIntegration(t *testing.T) {
+	protocol := "tcp"
+	host := "test.com"
+	port := 8080
+
+	expectedConfig := mqtt.MQTTClientConfig{
+		BrokerURL: fmt.Sprintf("%s://%s:%d", protocol, host, port),
+		MQTTClientOptions: mqtt.MQTTClientOptions{
+			Username:       "ProvidedUsername",
+			Password:       "ProvidedPassword",
+			ClientId:       "ProvidedClientId",
+			Qos:            99,
+			KeepAlive:      98,
+			Retained:       true,
+			AutoReconnect:  true,
+			ConnectTimeout: 97,
+			SkipCertVerify: true,
+			CertFile:       "ProvidedCertFile",
+			KeyFile:        "ProvidedKeyFile",
+			KeyPEMBlock:    "ProvidedKeyPEMBlock",
+			CertPEMBlock:   "ProvidedCertPEMBlock",
+		},
+	}
+	optionalConfigurations := NewMQTTOptionalConfigurationBuilder().
+		Username(expectedConfig.Username).
+		Password(expectedConfig.Password).
+		ClientID(expectedConfig.ClientId).
+		Qos(expectedConfig.Qos).
+		KeepAlive(expectedConfig.KeepAlive).
+		Retained(expectedConfig.Retained).
+		AutoReconnect(expectedConfig.AutoReconnect).
+		ConnectTimeout(expectedConfig.ConnectTimeout).
+		SkipCertVerify(expectedConfig.SkipCertVerify).
+		CertFile(expectedConfig.CertFile).
+		KeyFile(expectedConfig.KeyFile).
+		KeyPEMBlock(expectedConfig.KeyPEMBlock).
+		CertPEMBlock(expectedConfig.CertPEMBlock).
+		Build()
+
+	messageBusConfig := types.MessageBusConfig{
+		PublishHost: types.HostInfo{
+			Host:     host,
+			Port:     port,
+			Protocol: protocol,
+		},
+		Optional: optionalConfigurations,
+	}
+
+	observedResult, err := mqtt.CreateMQTTClientConfiguration(messageBusConfig)
+	require.NoError(t, err)
+	assert.Equal(t, expectedConfig, observedResult)
+}

--- a/messaging/mqtt/constants.go
+++ b/messaging/mqtt/constants.go
@@ -1,0 +1,39 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// Package mqtt provides functionality useful for interacting with the MQTT client implementation.
+package mqtt
+
+const (
+	// Constants for configuration properties provided via the MessageBusConfig's Optional field.
+
+	// Client identifier configurations
+	Username = "Username"
+	Password = "Password"
+	ClientId = "ClientId"
+
+	// Connection configuration names
+	Qos            = "Qos"
+	KeepAlive      = "KeepAlive"
+	Retained       = "Retained"
+	AutoReconnect  = "AutoReconnect"
+	ConnectTimeout = "ConnectTimeout"
+
+	// TLS configuration names
+	SkipCertVerify = "SkipCertVerify"
+	CertFile       = "CertFile"
+	KeyFile        = "KeyFile"
+	KeyPEMBlock    = "KeyPEMBlock"
+	CertPEMBlock   = "CertPEMBlock"
+)


### PR DESCRIPTION
Fix #41

Update MQTT client, client options, and constructors to allow for
configuration of TLS communication.

Create a helper file configuration.go which contains a struct and
methods which will aid users in creating optional configuration
properties when creating a MQTT client

Update tests to cover newly added functionality.

Updated README to reference the newly added configuration.go file for
creating configuration properties.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>