### PR TITLE
fix(redisstreams): Properly set Password via reflection when found in Options

### DIFF
--- a/internal/pkg/redis/streams/client.go
+++ b/internal/pkg/redis/streams/client.go
@@ -206,5 +206,5 @@ func createRedisClient(
 		return nil, err
 	}
 
-	return creator(redisServerURL, optionalClientConfiguration.password, tlsConfig)
+	return creator(redisServerURL, optionalClientConfiguration.Password, tlsConfig)
 }

--- a/internal/pkg/redis/streams/configuration_options.go
+++ b/internal/pkg/redis/streams/configuration_options.go
@@ -22,7 +22,7 @@ import (
 // OptionalClientConfiguration contains additional configuration properties which can be provided via the
 // MessageBus.Optional's field.
 type OptionalClientConfiguration struct {
-	password string
+	Password string
 }
 
 // NewClientConfiguration creates a OptionalClientConfiguration based on the configuration properties provided.

--- a/internal/pkg/redis/streams/configuration_options_test.go
+++ b/internal/pkg/redis/streams/configuration_options_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestNewClientConfiguration(t *testing.T) {
+	expectedPassword := "MyPassword"
+
 	tests := []struct {
 		name    string
 		config  types.MessageBusConfig
@@ -31,8 +33,29 @@ func TestNewClientConfiguration(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "Create Non TLS OptionalClientConfiguration",
+			name:    "Create Non Auth OptionalClientConfiguration",
 			config:  types.MessageBusConfig{},
+			want:    OptionalClientConfiguration{},
+			wantErr: false,
+		},
+		{
+			name: "Create Auth uppercase OptionalClientConfiguration",
+			config: types.MessageBusConfig{
+				Optional: map[string]string{
+					"Password": expectedPassword,
+				},
+			},
+			want:    OptionalClientConfiguration{Password: expectedPassword},
+			wantErr: false,
+		},
+		{
+			name: "Create Auth lowercase OptionalClientConfiguration",
+			config: types.MessageBusConfig{
+				Optional: map[string]string{
+					"password": expectedPassword,
+				},
+			},
+			// Expect the password not not be set since the name/key is lowercase in the map
 			want:    OptionalClientConfiguration{},
 			wantErr: false,
 		},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?

Setting password in Optional with key "Password" is ignored. 
Setting password in Optional with key "password" is fails due to reflection can't set private field. 

## Issue Number:  #68


## What is the new behavior?

Setting password in Optional with key "Password" works properly. 
Setting password in Optional with key "password" is ignored properly 


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
no
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information