### PR TITLE
fix: Change CorrelationID key constant to match recent change in edgex-go

### DIFF
--- a/internal/pkg/zeromq/client_test.go
+++ b/internal/pkg/zeromq/client_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 	zmq "github.com/pebbe/zmq4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -479,26 +480,18 @@ func TestPublishWihMultipleSubscribersWithTopic(t *testing.T) {
 	}
 
 	err = zmqClientAppFunc1.Subscribe(appFuncTopic1, appFuncMessageErrors1)
-	if !assert.Nil(t, err, "Failed to subscribe to ZMQ message") {
-		t.Fatal()
-	}
+	require.NoError(t, err, "Failed to subscribe to ZMQ message")
 
 	err = zmqClientAppFunc2.Subscribe(appFuncTopic2, appFuncMessageErrors2)
-	if !assert.Nil(t, err, "Failed to subscribe to ZMQ message") {
-		t.Fatal()
-	}
+	require.NoError(t, err, "Failed to subscribe to ZMQ message")
 
 	time.Sleep(time.Second)
 
 	err = zmqClientCoreData.Publish(coreDataMessage, coreDataPublishTopic)
-	if !assert.Nil(t, err, "Failed to publish ZMQ message") {
-		t.Fatal()
-	}
+	require.NoError(t, err, "Failed to publish ZMQ message")
 
 	err = zmqClientAppFunc1.Publish(appFuncMessage, appFunctionPublishTopic)
-	if !assert.Nil(t, err, "Failed to publish ZMQ message") {
-		t.Fatal()
-	}
+	require.NoError(t, err, "Failed to publish ZMQ message")
 
 	testTimer := time.NewTimer(time.Second)
 	defer testTimer.Stop()

--- a/pkg/types/message_envelope.go
+++ b/pkg/types/message_envelope.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	checksum      = "payload-checksum"
-	correlationId = "correlation-id"
+	correlationId = "X-Correlation-ID"
 	contentType   = "Content-Type"
 )
 
@@ -41,6 +41,8 @@ type MessageEnvelope struct {
 // NewMessageEnvelope creates a new MessageEnvelope for the specified payload with attributes from the specified context
 func NewMessageEnvelope(payload []byte, ctx context.Context) MessageEnvelope {
 	envelope := MessageEnvelope{
+		// TODO: Remove Checksum for V2.0 release.
+		//       Also consider just passing correlationId & contentType as parameters instead of Context
 		Checksum:      fromContext(ctx, checksum),
 		CorrelationID: fromContext(ctx, correlationId),
 		ContentType:   fromContext(ctx, contentType),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?

CorrelationID is passed in the Context. The key to extracted it from the context
changed to match the key used in the HTTP Header.


## Issue Number: #70


## What is the new behavior?

Key constant update to latest correct value.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?


no

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information