### PR TITLE
fix: Adjusted missing v2 in remaining paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/edgexfoundry/go-mod-messaging/v2
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
-	github.com/edgexfoundry/go-mod-messaging v0.1.30
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/pebbe/zmq4 v1.2.2
 	github.com/stretchr/testify v1.3.0

--- a/internal/pkg/mqtt/client_integration_test.go
+++ b/internal/pkg/mqtt/client_integration_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/edgexfoundry/go-mod-messaging/messaging/mqtt"
+	"github.com/edgexfoundry/go-mod-messaging/v2/messaging/mqtt"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 )
 

--- a/internal/pkg/redis/streams/client_test.go
+++ b/internal/pkg/redis/streams/client_test.go
@@ -32,9 +32,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-messaging/messaging/redis"
 	"github.com/edgexfoundry/go-mod-messaging/v2/internal/pkg"
 	"github.com/edgexfoundry/go-mod-messaging/v2/internal/pkg/redis/streams/mocks"
+	"github.com/edgexfoundry/go-mod-messaging/v2/messaging/redis"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/master/.github/Contributing.md.

## What is the current behavior?
Missed a couple v2 update in imports which cause the IDE to add v0.x.x version in the go.mod file.

## Issue Number: #87


## What is the new behavior?
All import paths now have v2 and module does import its older self.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information