### PR TITLE
refactor: Add Done() method to MockToken for latest Paho module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/edgexfoundry/go-mod-messaging/v2
 
 require (
-	github.com/eclipse/paho.mqtt.golang v1.2.0
+	github.com/eclipse/paho.mqtt.golang v1.3.2
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/pebbe/zmq4 v1.2.5
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 )
 
 go 1.15


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/master/.github/Contributing.md.

## What is the current behavior?
Latest Paho module breaks build as the new Done API was add that our MockToken doesn't implement

## Issue Number:  #83


## What is the new behavior?
Update to latest Paho module and added Done() func to the MockToken

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information