### PR TITLE
fix: Resolve race condition in ZMQ impl when binding to port

### DIFF
--- a/internal/pkg/zeromq/client.go
+++ b/internal/pkg/zeromq/client.go
@@ -66,11 +66,10 @@ func (client *zeromqClient) Publish(message types.MessageEnvelope, topic string)
 
 	var err error
 
-	if client.publisher == nil {
-		err = client.bindToPort(client.config.PublishHost.GetHostURL())
-		if err != nil {
-			return err
-		}
+	// Safely binds to port if not already done.
+	err = client.bindToPort(client.config.PublishHost.GetHostURL())
+	if err != nil {
+		return err
 	}
 
 	marshaledMsg, err := json.Marshal(message)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/master/.github/Contributing.md.

## What is the current behavior?
`Publisher` is checked for nil outside the locked section that sets it, which causes a race condition.

## Issue Number: #95


## What is the new behavior?
`Publisher` is not checked outside the locked section that sets it, which resolves the race condition


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information