### PR TITLE
feat: Add ReceivedTopic to MessageEnvelope & remove Checksum

### DIFF
--- a/internal/pkg/mqtt/client.go
+++ b/internal/pkg/mqtt/client.go
@@ -231,6 +231,8 @@ func newMessageHandler(
 			errorChannel <- err
 		}
 
+		messageEnvelope.ReceivedTopic = message.Topic()
+
 		messageChannel <- messageEnvelope
 	}
 }

--- a/internal/pkg/redis/streams/client.go
+++ b/internal/pkg/redis/streams/client.go
@@ -145,6 +145,8 @@ func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error)
 					continue
 				}
 
+				message.ReceivedTopic = convertFromRedisTopicScheme(message.ReceivedTopic)
+
 				messageChannel <- *message
 			}
 		}()
@@ -207,6 +209,16 @@ func convertToRedisTopicScheme(topic string) string {
 	// convert it to the RedisStreams scheme.
 	topic = strings.Replace(topic, StandardTopicSeparator, RedisTopicSeparator, -1)
 	topic = strings.Replace(topic, StandardWildcard, RedisWildcard, -1)
+
+	return topic
+}
+
+func convertFromRedisTopicScheme(topic string) string {
+	// RedisStreams uses "." for separator and "*" for wild cards.
+	// Since we have standardized on the MQTT style scheme or "/" & "#" we need to
+	// convert it from the RedisStreams scheme.
+	topic = strings.Replace(topic, RedisTopicSeparator, StandardTopicSeparator, -1)
+	topic = strings.Replace(topic, RedisWildcard, StandardWildcard, -1)
 
 	return topic
 }

--- a/internal/pkg/redis/streams/goredis.go
+++ b/internal/pkg/redis/streams/goredis.go
@@ -87,6 +87,8 @@ func (g *goRedisWrapper) Receive(topic string) (*types.MessageEnvelope, error) {
 		return nil, fmt.Errorf("unable to unmarshal payload: %w", err)
 	}
 
+	message.ReceivedTopic = data.Channel
+
 	return message, nil
 }
 

--- a/pkg/types/message_envelope.go
+++ b/pkg/types/message_envelope.go
@@ -28,8 +28,8 @@ const (
 
 // MessageEnvelope is the data structure for messages. It wraps the generic message payload with attributes.
 type MessageEnvelope struct {
-	// Checksum used to communicate to core-data that an Event message has been received via the message bus
-	Checksum string
+	// ReceivedTopic is the topic that the message was receive on.
+	ReceivedTopic string
 	// CorrelationID is an object id to identify the envelop
 	CorrelationID string
 	// Payload is byte representation of the data being transferred.
@@ -41,9 +41,6 @@ type MessageEnvelope struct {
 // NewMessageEnvelope creates a new MessageEnvelope for the specified payload with attributes from the specified context
 func NewMessageEnvelope(payload []byte, ctx context.Context) MessageEnvelope {
 	envelope := MessageEnvelope{
-		// TODO: Remove Checksum for V2.0 release.
-		//       Also consider just passing correlationId & contentType as parameters instead of Context
-		Checksum:      fromContext(ctx, checksum),
 		CorrelationID: fromContext(ctx, correlationId),
 		ContentType:   fromContext(ctx, contentType),
 		Payload:       payload,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/master/.github/Contributing.md.

## What is the current behavior?
Obsolete Checksum property exists
Not property to indicate the topic the data was received on.

## Issue Number:  #77 & #100


## What is the new behavior?
ReceivedTopic is set to the topic that the message was received for from the MessageBus
Obsolete Checksum property was removed

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Checksum property has been removed from the MessageEnvelope

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information