### PR TITLE
fix: Use Qos and Retained value from configuration

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -1,7 +1,0 @@
-The following open source projects are referenced by go-mod-messaging:
-
-eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
-https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
-
-pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
-https://github.com/pebbe/zmq4/blob/master/LICENSE.txt

--- a/internal/pkg/mqtt/client.go
+++ b/internal/pkg/mqtt/client.go
@@ -132,6 +132,7 @@ func (mc *Client) Publish(message types.MessageEnvelope, topic string) error {
 	}
 
 	optionsReader := mc.mqttClient.OptionsReader()
+
 	return getTokenError(
 		mc.mqttClient.Publish(
 			topic,
@@ -151,6 +152,7 @@ func (mc *Client) Subscribe(topics []types.TopicChannel, messageErrors chan erro
 	for _, topic := range topics {
 		handler := newMessageHandler(mc.unmarshaller, topic.Messages, messageErrors)
 		qos := optionsReader.WillQos()
+
 		token := mc.mqttClient.Subscribe(topic.Topic, qos, handler)
 		err := getTokenError(token, optionsReader.ConnectTimeout(), SubscribeOperation, "Failed to create subscription")
 		if err != nil {
@@ -275,6 +277,8 @@ func createClientOptions(
 	clientOptions.SetPassword(clientConfiguration.Password)
 	clientOptions.SetClientID(clientConfiguration.ClientId)
 	clientOptions.SetKeepAlive(time.Duration(clientConfiguration.KeepAlive) * time.Second)
+	clientOptions.WillQos = byte(clientConfiguration.Qos)
+	clientOptions.WillRetained = clientConfiguration.Retained
 	clientOptions.SetAutoReconnect(clientConfiguration.AutoReconnect)
 	clientOptions.SetConnectTimeout(time.Duration(clientConfiguration.ConnectTimeout) * time.Second)
 	tlsConfiguration, err := pkg.GenerateTLSForClientClientOptions(

--- a/internal/pkg/mqtt/client_test.go
+++ b/internal/pkg/mqtt/client_test.go
@@ -922,3 +922,34 @@ func mockCertLoader(returnError error) pkg.X509KeyLoader {
 		return tls.Certificate{}, returnError
 	}
 }
+
+func TestCreateClientOptions(t *testing.T) {
+	config := MQTTClientConfig{
+		BrokerURL: "",
+		MQTTClientOptions: MQTTClientOptions{
+			ClientId:       "Test",
+			Qos:            2,
+			KeepAlive:      50,
+			Retained:       true,
+			AutoReconnect:  true,
+			ConnectTimeout: 60,
+			TlsConfigurationOptions: pkg.TlsConfigurationOptions{
+				SkipCertVerify: false,
+				CertFile:       "",
+				KeyFile:        "",
+				KeyPEMBlock:    "",
+				CertPEMBlock:   "",
+			},
+		},
+	}
+
+	options, err := createClientOptions(config, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, config.ClientId, options.ClientID)
+	assert.Equal(t, byte(config.Qos), options.WillQos)
+	assert.Equal(t, config.Retained, options.WillRetained)
+	assert.Equal(t, int64(config.KeepAlive), options.KeepAlive)
+	assert.Equal(t, config.AutoReconnect, options.AutoReconnect)
+	assert.Equal(t, time.Duration(config.ConnectTimeout)*time.Second, options.ConnectTimeout)
+}


### PR DESCRIPTION
Now WillQos and WillRetained are set from the values in configuration

fixes #112

Also removed unneeded Attribution.tx file

closes #32

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      **No docs change required**

## Testing Instructions
Had to test these setting. temporarily added print statements to publish and subscribe to validate the values in the config are used.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->