### PR TITLE
refactor: Disable use of ZMQ on native windows via conditional builds

### DIFF
--- a/internal/pkg/zeromq/linux_client.go
+++ b/internal/pkg/zeromq/linux_client.go
@@ -1,5 +1,7 @@
+//go:build linux
+// +build linux
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/pkg/zeromq/linux_client_test.go
+++ b/internal/pkg/zeromq/linux_client_test.go
@@ -1,5 +1,7 @@
+//go:build linux
+// +build linux
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/pkg/zeromq/linux_subscriber_test.go
+++ b/internal/pkg/zeromq/linux_subscriber_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+// +build linux
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package zeromq
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+)
+
+func TestSubscriberInit(t *testing.T) {
+	zeromqSubscriber := zeromqSubscriber{}
+
+	msqURL := "tcp://localhost:5690"
+	aTopic := types.TopicChannel{Topic: "test", Messages: nil}
+	if err := zeromqSubscriber.init(msqURL, &aTopic); err != nil {
+		t.Fatalf("cannot init subscriber with URL %s and topic %v", msqURL, aTopic)
+	}
+}
+
+func TestSubscriberInitNullTopic(t *testing.T) {
+	zeromqSubscriber := zeromqSubscriber{}
+
+	msqURL := "tcp://localhost:5690"
+
+	if err := zeromqSubscriber.init(msqURL, nil); err != nil {
+		t.Fatalf("cannot init subscriber with URL %s and null topic", msqURL)
+	}
+}

--- a/internal/pkg/zeromq/windows_client.go
+++ b/internal/pkg/zeromq/windows_client.go
@@ -1,0 +1,51 @@
+//go:build windows
+// +build windows
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package zeromq
+
+import (
+	"errors"
+
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+)
+
+var notSupportedErrorMessage = errors.New("zmq is no longer supported on windows native deployments")
+
+type zeromqClient struct {
+}
+
+func NewZeroMqClient(_ types.MessageBusConfig) (*zeromqClient, error) {
+	return nil, notSupportedErrorMessage
+}
+
+func (client *zeromqClient) Connect() error {
+	return notSupportedErrorMessage
+}
+
+func (client *zeromqClient) Publish(_ types.MessageEnvelope, _ string) error {
+	return notSupportedErrorMessage
+
+}
+
+func (client *zeromqClient) Subscribe(_ []types.TopicChannel, _ chan error) error {
+	return notSupportedErrorMessage
+}
+
+func (client *zeromqClient) Disconnect() error {
+	return notSupportedErrorMessage
+}

--- a/messaging/factory_test.go
+++ b/messaging/factory_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,16 +30,6 @@ var msgConfig = types.MessageBusConfig{
 		Port:     5570,
 		Protocol: "tcp",
 	},
-}
-
-func TestNewMessageClientZeroMq(t *testing.T) {
-
-	msgConfig.Type = ZeroMQ
-	_, err := NewMessageClient(msgConfig)
-
-	if assert.NoError(t, err, "New Message client failed: ", err) == false {
-		t.Fatal()
-	}
 }
 
 func TestNewMessageClientMQTT(t *testing.T) {

--- a/messaging/linux_factory_test.go
+++ b/messaging/linux_factory_test.go
@@ -1,5 +1,7 @@
+//go:build linux
+// +build linux
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,36 +16,26 @@
 // limitations under the License.
 //
 
-package zeromq
+package messaging
 
 import (
+	"testing"
+
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 
-	zmq "github.com/pebbe/zmq4"
+	"github.com/stretchr/testify/require"
 )
 
-type zeromqSubscriber struct {
-	connection *zmq.Socket
-	topic      types.TopicChannel
-	context    *zmq.Context
-}
-
-func (subscriber *zeromqSubscriber) init(msgQueueURL string, topic *types.TopicChannel) (err error) {
-
-	if subscriber.connection == nil {
-		subscriber.context, err = zmq.NewContext()
-
-		if err != nil {
-			return err
-		}
-
-		if subscriber.connection, err = subscriber.context.NewSocket(zmq.SUB); err != nil {
-			return err
-		}
-	}
-	if topic != nil {
-		subscriber.topic = *topic
+func TestNewMessageClientZeroMq_Linux(t *testing.T) {
+	config := types.MessageBusConfig{
+		Type: ZeroMQ,
+		PublishHost: types.HostInfo{
+			Host:     "*",
+			Port:     5570,
+			Protocol: "tcp",
+		},
 	}
 
-	return subscriber.connection.Connect(msgQueueURL)
+	_, err := NewMessageClient(config)
+	require.NoError(t, err)
 }

--- a/messaging/windows_factory_test.go
+++ b/messaging/windows_factory_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+// +build windows
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package messaging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+)
+
+func TestNewMessageClientZeroMq_Windows(t *testing.T) {
+	expected := "zmq is no longer supported on windows native deployments"
+	config := types.MessageBusConfig{
+		Type: ZeroMQ,
+		PublishHost: types.HostInfo{
+			Host:     "*",
+			Port:     5570,
+			Protocol: "tcp",
+		},
+	}
+
+	_, err := NewMessageClient(config)
+	require.Error(t, err)
+	assert.Equal(t, expected, err.Error())
+}


### PR DESCRIPTION
This allows services that use this module to build native on windows with out installing the ZeroMQ dependency.

BREAKING CHANGE: This disables use of ZMQ when running windows native builds.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  **TBD**

## Testing Instructions

- Run no-secure EdgeX stack and stop Core Data
- Update edgex-go go.mod to use the branch for this PR for go-mod-messaging
- Build Core Data native on windows
- Change LogLevel for Core Data to DEBUG
- Run Core Data native on windows with `EDGEX_SECURITY_SECRET_STORE=false`
- Verify logs show connected to Redis message bus
- Verify logs show Core Data receiving and persisting Events from Device Virtual via the message bus

## New Dependency Instructions (If applicable)
N/A