### PR TITLE
feat(security): Enable gosec and default linter set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: test unittest lint
 
+ARCH=$(shell uname -m)
 GO=CGO_ENABLED=1 GO111MODULE=on go
 
 tidy:


### PR DESCRIPTION
Fixes #118

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make lint

## Notes
ARCH is now set in the Makefile.
Fixes omission that causes linter not to run if ARCH not set on host system's environment by default.
