### PR TITLE
fix: pass a copy of topic to redis subscriber

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ tidy:
 	go mod tidy
 
 unittest:
-	$(GO) test ./... -coverprofile=coverage.out ./...
+	$(GO) test -race ./... -coverprofile=coverage.out ./...
 
 lint:
 	@which golangci-lint >/dev/null || echo "WARNING: go linter not installed. To install, run\n  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$$(go env GOPATH)/bin v1.42.1"

--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -133,11 +133,11 @@ func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error)
 		return pkg.NewMissingConfigurationErr("SubscribeHostInfo", "Unable to create a connection for subscribing")
 	}
 
-	for _, topic := range topics {
-		topicName := convertToRedisTopicScheme(topic.Topic)
-		messageChannel := topic.Messages
+	for i := range topics {
 
-		go func() {
+		go func(topic types.TopicChannel) {
+			topicName := convertToRedisTopicScheme(topic.Topic)
+			messageChannel := topic.Messages
 			for {
 				message, err := c.subscribeClient.Receive(topicName)
 				if err != nil {
@@ -149,7 +149,7 @@ func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error)
 
 				messageChannel <- *message
 			}
-		}()
+		}(topics[i])
 	}
 
 	return nil

--- a/internal/pkg/redis/client_test.go
+++ b/internal/pkg/redis/client_test.go
@@ -421,19 +421,23 @@ func (r *SubscriptionRedisClientMock) Send(string, types.MessageEnvelope) error 
 }
 
 func (r *SubscriptionRedisClientMock) Receive(topic string) (*types.MessageEnvelope, error) {
+	r.counterMutex.Lock()
+
 	if r.messagesReturned < r.NumberOfMessages {
-		r.counterMutex.Lock()
-		defer r.counterMutex.Unlock()
 		r.messagesReturned++
+
+		defer r.counterMutex.Unlock()
 		return createMessage(topic, r.messagesReturned), nil
 	}
 
 	if r.errorsReturned < r.NumberOfErrors {
-		r.counterMutex.Lock()
+		r.errorsReturned++
+
 		defer r.counterMutex.Unlock()
-		r.errorsReturned += 1
 		return nil, errors.New("test error")
 	}
+
+	r.counterMutex.Unlock()
 
 	for {
 		// Sleep to simulate no more messages which will block the caller.

--- a/internal/pkg/redis/client_test.go
+++ b/internal/pkg/redis/client_test.go
@@ -298,7 +298,6 @@ func TestClient_Publish(t *testing.T) {
 }
 
 func TestClient_Subscribe(t *testing.T) {
-	Topic := "UnitTestTopic"
 	tests := []struct {
 		name             string
 		numberOfMessages int
@@ -332,29 +331,35 @@ func TestClient_Subscribe(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewClientWithCreator(types.MessageBusConfig{
-				SubscribeHost: HostInfo,
-			},
+			// Since SubscriptionRedisClientMock doesn't have counters per topic,
+			// the numberOfMessages and numberOfErrors will not change depending
+			// on the number of topics. That's because the total messages mocked
+			// by the Receive method is client specific.
+			c, err := NewClientWithCreator(
+				types.MessageBusConfig{
+					SubscribeHost: HostInfo,
+				},
 				mockSubscriptionClientCreator(tt.numberOfMessages, tt.numberOfErrors),
 				mockCertCreator(nil),
-				mockCertLoader(nil))
-
+				mockCertLoader(nil),
+			)
 			require.NoError(t, err)
-			messageChannel := make(chan types.MessageEnvelope)
+
 			topics := []types.TopicChannel{
 				{
-					Topic:    Topic,
-					Messages: messageChannel,
+					Topic:    "UnitTestTopic",
+					Messages: make(chan types.MessageEnvelope),
+				},
+				{
+					Topic:    "UnitTestTopic2",
+					Messages: make(chan types.MessageEnvelope),
 				},
 			}
 
 			errorMessageChannel := make(chan error)
 			err = c.Subscribe(topics, errorMessageChannel)
 			require.NoError(t, err)
-			receivedExpectedMessagesWaitGroup := &sync.WaitGroup{}
-			receivedExpectedMessagesWaitGroup.Add(1)
-			readFromChannel(t, Topic, messageChannel, tt.numberOfMessages, errorMessageChannel, tt.numberOfErrors, receivedExpectedMessagesWaitGroup)
-			receivedExpectedMessagesWaitGroup.Wait()
+			readFromChannel(t, topics, tt.numberOfMessages, errorMessageChannel, tt.numberOfErrors)
 		})
 	}
 }
@@ -461,27 +466,39 @@ func createMessage(topic string, messageNumber int) *types.MessageEnvelope {
 
 func readFromChannel(
 	t *testing.T,
-	expectedTopic string,
-	messageChannel <-chan types.MessageEnvelope,
+	topics []types.TopicChannel,
 	expectedNumberOfMessages int,
 	errorsChannel <-chan error,
 	expectedNumberOfErrors int,
-	group *sync.WaitGroup) {
+) {
+
+	if len(topics) != 2 {
+		panic("Length of input topics should be 2")
+	}
 
 	for expectedNumberOfMessages > 0 || expectedNumberOfErrors > 0 {
 		select {
-		case message := <-messageChannel:
-			assert.Equal(t, expectedTopic, message.ReceivedTopic, "ReceivedTopic not as expected")
+		case message := <-topics[0].Messages:
+			assert.Equal(t, topics[0].Topic, message.ReceivedTopic, "ReceivedTopic not as expected")
+			expectedNumberOfMessages -= 1
+			continue
+
+		case message := <-topics[1].Messages:
+			assert.Equal(t, topics[1].Topic, message.ReceivedTopic, "ReceivedTopic not as expected")
 			expectedNumberOfMessages -= 1
 			continue
 
 		case <-errorsChannel:
 			expectedNumberOfErrors -= 1
 			continue
+
+		case <-time.After(10 * time.Second):
+			t.Fatal("Timed out waiting for messages")
 		}
 	}
 
-	group.Done()
+	require.Zero(t, expectedNumberOfMessages, "Too many messages")
+	require.Zero(t, expectedNumberOfErrors, "Too many errors")
 }
 
 func TestClient_Disconnect(t *testing.T) {


### PR DESCRIPTION
This is to avoid race condition when the loop iterates faster than go routines run. It fixes #130

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix
- [x] I have fully tested (add details below) this the new feature or bug fix - unit tested
- [ ] I have opened a PR for the related docs change - N/A

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->