### PR TITLE
fix: Adjust build constraints to allow ZMQ on all OSes except Windows

### DIFF
--- a/internal/pkg/zeromq/client.go
+++ b/internal/pkg/zeromq/client.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 //
 // Copyright (c) 2021 Intel Corporation

--- a/internal/pkg/zeromq/client_test.go
+++ b/internal/pkg/zeromq/client_test.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 //
 // Copyright (c) 2021 Intel Corporation

--- a/internal/pkg/zeromq/subscriber.go
+++ b/internal/pkg/zeromq/subscriber.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 //
 // Copyright (c) 2021 Intel Corporation

--- a/internal/pkg/zeromq/subscriber_test.go
+++ b/internal/pkg/zeromq/subscriber_test.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 //
 // Copyright (c) 2021 Intel Corporation


### PR DESCRIPTION
closes #131

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Existing suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**

## Testing Instructions
Use branch in edgex-go
Build edgex-go on Linus & Windows and Mac if has access

## New Dependency Instructions (If applicable)
**N/A**