### PR TITLE
fix: Disallow subscribing to same exact topic multiple times

### DIFF
--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/edgexfoundry/go-mod-messaging/v2/internal/pkg"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
@@ -36,6 +37,10 @@ const (
 type Client struct {
 	// Client used for functionality related to reading messages
 	subscribeClient RedisClient
+
+	// Used to avoid multiple subscriptions to the same topic
+	existingTopics map[string]bool
+	mapMutex       *sync.Mutex
 
 	// Client used for functionality related to sending messages
 	publishClient RedisClient
@@ -101,6 +106,8 @@ func NewClientWithCreator(
 
 	return Client{
 		subscribeClient: subscribeClient,
+		existingTopics:  make(map[string]bool),
+		mapMutex:        new(sync.Mutex),
 		publishClient:   publishClient,
 	}, nil
 }
@@ -131,6 +138,11 @@ func (c Client) Publish(message types.MessageEnvelope, topic string) error {
 func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error) error {
 	if c.subscribeClient == nil {
 		return pkg.NewMissingConfigurationErr("SubscribeHostInfo", "Unable to create a connection for subscribing")
+	}
+
+	err := c.validateTopics(topics)
+	if err != nil {
+		return err
 	}
 
 	for i := range topics {
@@ -176,6 +188,23 @@ func (c Client) Disconnect() error {
 
 	if len(disconnectErrors) > 0 {
 		return NewDisconnectErr(disconnectErrors)
+	}
+
+	return nil
+}
+
+func (c Client) validateTopics(topics []types.TopicChannel) error {
+	c.mapMutex.Lock()
+	defer c.mapMutex.Unlock()
+
+	// First validate all the topics are unique, i.e. not existing subscription
+	for _, topic := range topics {
+		_, exists := c.existingTopics[topic.Topic]
+		if exists {
+			return fmt.Errorf("subscription for '%s' topic already exists, must be unique", topic.Topic)
+		}
+
+		c.existingTopics[topic.Topic] = true
 	}
 
 	return nil


### PR DESCRIPTION
fixes #133

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Code not unit testable**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Use branch for this PR in App SDK template app
Configure template app subscriptions to be `SubscribeTopics="edgex/events/#,edgex/events/#"
Build and run template app
Verify fails with following message:
```
"failed to subscribe to topic(s) 'edgex/events/#,edgex/events/#': subscription for 'edgex/events/#' topic already exists, must be unique"
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->