### PR TITLE
feat: Add build flag to build w/o messaging capability

### DIFF
--- a/messaging/factory.go
+++ b/messaging/factory.go
@@ -1,5 +1,8 @@
+//go:build !no_messagebus
+// +build !no_messagebus
+
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/messaging/factory_noop.go
+++ b/messaging/factory_noop.go
@@ -1,0 +1,33 @@
+//go:build no_messagebus
+// +build no_messagebus
+
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package messaging
+
+import (
+	"errors"
+
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+)
+
+// NewMessageClient is noop implementation when service doesn't need the message bus.
+// This is need when this module is included in the common go-mod-bootstrap, but some service
+// such as security service have no need for messaging.
+func NewMessageClient(msgConfig types.MessageBusConfig) (MessageClient, error) {
+	return nil, errors.New("messaging was disabled during build with the no_messagebus build flag")
+}


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Using this branch in edgex-go
Change core-metadata build back to GO and GOFLAG
Build and verify it fails due to ZMQ dependencies
Add `-tags no_messagebus` to core-metadata build
```
$(GO) build $(GOFLAGS) -tags no_messagebus -o $@ ./cmd/core-metadata
```
Verify builds and runs fine.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->