### PR TITLE
feat: Allow user to bring their own CA in the client

### DIFF
--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -16,6 +16,9 @@ package pkg
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -30,12 +33,24 @@ type X509KeyPairCreator func(certPEMBlock []byte, keyPEMBlock []byte) (tls.Certi
 // X509KeyLoader defines a function signature for loading a tls.Certificate from cert and key files.
 type X509KeyLoader func(certFile string, keyFile string) (tls.Certificate, error)
 
+// X509CaCertLoader defines the function signature for loading a PEM formatted block from the given CA certificate file.
+type X509CaCertLoader func(caCertFile string) ([]byte, error)
+
+// PEMDecoder defines the function signature for finding the next PEM formatted block in the input. It returns that
+// block and the remainder of the input.
+type PEMDecoder func(data []byte) (*pem.Block, []byte)
+
+// X509CaCertCreator defines the function signature for creating a CA certificate based on PEM encoding.
+type X509CaCertCreator func(caCertPEMBlock []byte) (*x509.Certificate, error)
+
 type TlsConfigurationOptions struct {
 	SkipCertVerify bool
 	CertFile       string
 	KeyFile        string
+	CaFile         string
 	KeyPEMBlock    string
 	CertPEMBlock   string
+	CaPEMBlock     string
 }
 
 func CreateDefaultTlsConfigurationOptions() TlsConfigurationOptions {
@@ -43,8 +58,10 @@ func CreateDefaultTlsConfigurationOptions() TlsConfigurationOptions {
 		SkipCertVerify: false,
 		CertFile:       "",
 		KeyFile:        "",
+		CaFile:         "",
 		KeyPEMBlock:    "",
 		CertPEMBlock:   "",
+		CaPEMBlock:     "",
 	}
 }
 
@@ -54,11 +71,15 @@ func GenerateTLSForClientClientOptions(
 	brokerURL string,
 	tlsConfigurationOptions TlsConfigurationOptions,
 	certCreator X509KeyPairCreator,
-	certLoader X509KeyLoader) (*tls.Config, error) {
+	certLoader X509KeyLoader,
+	caCertCreator X509CaCertCreator,
+	caCertLoader X509CaCertLoader,
+	pemDecoder PEMDecoder) (*tls.Config, error) {
 
-	// Nothing to do if the CertFile, KeyFile, CertPEMBlock, and KeyPEMBlock properties are not provided.
+	// Nothing to do if the CertFile, KeyFile, CertPEMBlock, KeyPEMBlock, CaFile, and CaPEMBlock properties are not provided.
 	if len(tlsConfigurationOptions.CertFile) <= 0 && len(tlsConfigurationOptions.KeyFile) <= 0 &&
-		len(tlsConfigurationOptions.CertPEMBlock) <= 0 && len(tlsConfigurationOptions.KeyPEMBlock) <= 0 {
+		len(tlsConfigurationOptions.CertPEMBlock) <= 0 && len(tlsConfigurationOptions.KeyPEMBlock) <= 0 &&
+		len(tlsConfigurationOptions.CaFile) <= 0 && len(tlsConfigurationOptions.CaPEMBlock) <= 0 {
 		return nil, nil
 	}
 
@@ -72,15 +93,29 @@ func GenerateTLSForClientClientOptions(
 			continue
 		}
 
-		cert, err := generateCertificate(tlsConfigurationOptions, certCreator, certLoader)
-		if err != nil {
-			return nil, err
-		}
-
 		tlsConfig := &tls.Config{
 			ClientCAs:          nil,
 			InsecureSkipVerify: tlsConfigurationOptions.SkipCertVerify, // nolint: gosec
-			Certificates:       []tls.Certificate{cert},
+			Certificates:       []tls.Certificate{},
+		}
+
+		if (len(tlsConfigurationOptions.CertFile) > 0 && len(tlsConfigurationOptions.KeyFile) > 0) ||
+			(len(tlsConfigurationOptions.CertPEMBlock) > 0 && len(tlsConfigurationOptions.KeyPEMBlock) > 0) {
+			cert, err := generateCertificate(tlsConfigurationOptions, certCreator, certLoader)
+			if err != nil {
+				return nil, err
+			}
+			tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+		}
+
+		if len(tlsConfigurationOptions.CaFile) > 0 || len(tlsConfigurationOptions.CaPEMBlock) > 0 {
+			caCert, err := generateCaCertificate(tlsConfigurationOptions, caCertCreator, caCertLoader, pemDecoder)
+			if err != nil {
+				return nil, err
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AddCert(caCert)
+			tlsConfig.RootCAs = caCertPool
 		}
 
 		return tlsConfig, nil
@@ -151,4 +186,35 @@ func Load(config map[string]string, des interface{}) error {
 		}
 	}
 	return nil
+}
+
+// generateCaCertificate creates a x509 CA certificate by either loading it from an existing CA cert file, or creates
+// a CA cert from the provided PEM bytes.
+func generateCaCertificate(tlsConfigurationOptions TlsConfigurationOptions,
+	caCertCreator X509CaCertCreator,
+	caCertLoader X509CaCertLoader,
+	pemDecoder PEMDecoder) (*x509.Certificate, error) {
+	var caCert *x509.Certificate
+	var err error
+	var caData []byte
+
+	if tlsConfigurationOptions.CaPEMBlock != "" {
+		caData = []byte(tlsConfigurationOptions.CaPEMBlock)
+	} else {
+		caData, err = caCertLoader(tlsConfigurationOptions.CaFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA file, error: %s", err.Error())
+		}
+	}
+
+	caPEMBlock, _ := pemDecoder(caData)
+	if caPEMBlock == nil {
+		return nil, errors.New("failed to find PEM formatted block in the CA file")
+	}
+	caCert, err = caCertCreator(caPEMBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificate, error: %s", err.Error())
+	}
+
+	return caCert, nil
 }

--- a/internal/pkg/constants.go
+++ b/internal/pkg/constants.go
@@ -16,8 +16,10 @@ const (
 	SkipCertVerify = "SkipCertVerify"
 	CertFile       = "CertFile"
 	KeyFile        = "KeyFile"
+	CaFile         = "CaFile"
 	KeyPEMBlock    = "KeyPEMBlock"
 	CertPEMBlock   = "CertPEMBlock"
+	CaPEMBlock     = "CaPEMBlock"
 
 	// MQTT Specifics
 	Qos          = "Qos"

--- a/internal/pkg/nats/options.go
+++ b/internal/pkg/nats/options.go
@@ -20,8 +20,11 @@ package nats
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/edgexfoundry/go-mod-messaging/v2/internal/pkg"
@@ -116,7 +119,8 @@ func (cc ClientConfig) ConnectOpt() ([]nats.Option, error) {
 		opts = append(opts, nats.UserInfo(cc.Username, cc.Password))
 	}
 
-	if tlsConfiguration, err := pkg.GenerateTLSForClientClientOptions(cc.BrokerURL, cc.TlsConfigurationOptions, tls.X509KeyPair, tls.LoadX509KeyPair); err == nil {
+	if tlsConfiguration, err := pkg.GenerateTLSForClientClientOptions(cc.BrokerURL, cc.TlsConfigurationOptions,
+		tls.X509KeyPair, tls.LoadX509KeyPair, x509.ParseCertificate, os.ReadFile, pem.Decode); err == nil {
 		if tlsConfiguration != nil {
 			opts = append(opts, nats.Secure(tlsConfiguration))
 		}


### PR DESCRIPTION
Fix: #142 

Signed-off-by: Felix Ting <felix@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) In EdgeX, the Redis client does not support TLS for now. https://github.com/edgexfoundry/edgex-go/blob/main/internal/pkg/db/redis/client.go#L43-L52
- [ ] I have opened a PR for the related docs change (if not, why?) no docs change
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->



## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->