### PR TITLE
fix: (jakarta) Disallow subscribing to same exact topic multiple times

### DIFF
--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -39,7 +39,7 @@ type Client struct {
 	subscribeClient RedisClient
 
 	// Used to avoid multiple subscriptions to the same topic
-	existingTopics map[string]bool
+	existingTopics map[string]struct{}
 	mapMutex       *sync.Mutex
 
 	// Client used for functionality related to sending messages
@@ -106,7 +106,7 @@ func NewClientWithCreator(
 
 	return Client{
 		subscribeClient: subscribeClient,
-		existingTopics:  make(map[string]bool),
+		existingTopics:  make(map[string]struct{}),
 		mapMutex:        new(sync.Mutex),
 		publishClient:   publishClient,
 	}, nil
@@ -203,7 +203,7 @@ func (c Client) validateTopics(topics []types.TopicChannel) error {
 			return fmt.Errorf("subscription for '%s' topic already exists, must be unique", topic.Topic)
 		}
 
-		c.existingTopics[topic.Topic] = true
+		c.existingTopics[topic.Topic] = struct{}{}
 	}
 
 	return nil


### PR DESCRIPTION
fixes #133 for jakarta
Back port of https://github.com/edgexfoundry/go-mod-messaging/pull/140 for jakarta

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Use branch for this PR in App SDK template app
Configure template app subscriptions to be `SubscribeTopics="edgex/events/#,edgex/events/#"
Build and run template app
Verify fails with following message:
```
"failed to subscribe to topic(s) 'edgex/events/#,edgex/events/#': subscription for 'edgex/events/#' topic already exists, must be unique"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->