### PR TITLE
feat: Handle repeated error better to not spam logs

### DIFF
--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -147,13 +147,15 @@ func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error)
 		return err
 	}
 
-	var previousErr error
 	for i := range topics {
 
 		go func(topic types.TopicChannel) {
 			topicName := convertToRedisTopicScheme(topic.Topic)
 			messageChannel := topic.Messages
+			var previousErr error
+
 			for {
+
 				message, err := c.subscribeClient.Receive(topicName)
 				if err != nil {
 					// This handles case when getting same repeated error due to Redis connectivity issue

--- a/internal/pkg/redis/client_test.go
+++ b/internal/pkg/redis/client_test.go
@@ -439,7 +439,7 @@ func (r *SubscriptionRedisClientMock) Receive(topic string) (*types.MessageEnvel
 		r.errorsReturned++
 
 		defer r.counterMutex.Unlock()
-		return nil, errors.New("test error")
+		return nil, fmt.Errorf("test error %d", r.errorsReturned) // Adding count to make error unique, so it isn't ignored as duplicate.
 	}
 
 	r.counterMutex.Unlock()


### PR DESCRIPTION
Also avoids starving other threads/processes due tight loop sending
errors.

closes #156

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Unable to unit test**
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Verified with App Template built with this branch
Stopped Redis
Verified logs not spammed and process not taking more than 10% of CPU.
Restarted Redis
Verified service received messages as expected

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->