### PR TITLE
feat: Add File-Based NKEY & Credentials Auth to NATS Client

### DIFF
--- a/internal/pkg/nats/options.go
+++ b/internal/pkg/nats/options.go
@@ -58,6 +58,8 @@ type ClientOptions struct {
 	QueueGroup              string
 	Deliver                 string
 	DefaultPubRetryAttempts int
+	NKeySeedFile            string
+	CredentialsFile         string
 }
 
 // CreateClientConfiguration constructs a ClientConfig based on the provided MessageBusConfig.
@@ -124,6 +126,18 @@ func (cc ClientConfig) ConnectOpt() ([]nats.Option, error) {
 		return nil, err
 	}
 
+	if cc.NKeySeedFile != "" {
+		nkOpt, err := nats.NkeyOptionFromSeed(cc.NKeySeedFile)
+
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, nkOpt)
+	}
+
+	if cc.CredentialsFile != "" {
+		opts = append(opts, nats.UserCredentials(cc.CredentialsFile))
+	}
 	return opts, nil
 }
 
@@ -139,5 +153,7 @@ func CreateClientOptionsWithDefaults() ClientOptions {
 		TlsConfigurationOptions: pkg.CreateDefaultTlsConfigurationOptions(),
 		DefaultPubRetryAttempts: nats.DefaultPubRetryAttempts,
 		Format:                  "nats",
+		NKeySeedFile:            "",
+		CredentialsFile:         "",
 	}
 }

--- a/internal/pkg/nats/options_test.go
+++ b/internal/pkg/nats/options_test.go
@@ -306,6 +306,23 @@ LhIhYpJ8UsCVt5snWo2N+M+6ANh5tpWdQnEK6zILh4tRbuzaiHgb
 					KeyPEMBlock:    "not PEM",
 				},
 			}}, 0, assert.Error},
+		{"NKEYS error", ClientConfig{
+			BrokerURL: "nats://broker",
+			ClientOptions: ClientOptions{
+				NKeySeedFile: "/fake/file/path.seed",
+			}}, 0, assert.Error},
+		// the NKeyOptionFromSeed option will validate the seed file on initialization
+		{"NKEYS", ClientConfig{
+			BrokerURL: "nats://broker",
+			ClientOptions: ClientOptions{
+				NKeySeedFile: "testdata/nkey.seed",
+			}}, 3, assert.NoError},
+		// the UserCredentials option does not validate the file passed on initialization
+		{"Credentials", ClientConfig{
+			BrokerURL: "nats://broker",
+			ClientOptions: ClientOptions{
+				CredentialsFile: "/fake/file/credentials",
+			}}, 3, assert.NoError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pkg/nats/testdata/nkey.seed
+++ b/internal/pkg/nats/testdata/nkey.seed
@@ -1,0 +1,4 @@
+# this file gets validated to create the option
+-----BEGIN USER NKEY SEED-----
+SUACSSL3UAHUDXKFSNVUZRF5UHPMWZ6BFDTJ7M6USDXIEDNPPQYYYCU3VY
+------END USER NKEY SEED------


### PR DESCRIPTION
Only supporting file-based options at the moment to avoid keeping key in
memory.  Fixes #167.

Signed-off-by: Alex Ullrich <alex.ullrich@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  will see on timing if this should go in Levski docs

## Testing Instructions
<!-- How can the reviewers test your change? -->

This is useful for setting up a local broker to perform NKEYS auth: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth

Or setup a memory resolver for testing JWT auth via credentials file: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt/mem_resolver


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->