### PR TITLE
feat: add new fields and factory functions for MessageEnvelope 

### DIFF
--- a/pkg/types/message_envelope.go
+++ b/pkg/types/message_envelope.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2022 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,34 +19,148 @@ package types
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
 )
 
 const (
-	correlationId = "X-Correlation-ID"
-	contentType   = "Content-Type"
+	ApiVersion      = "v2"
+	CorrelationID   = "X-Correlation-ID"
+	ContentType     = "Content-Type"
+	ContentTypeJSON = "application/json"
+	ContentTypeText = "text/plain"
 )
 
 // MessageEnvelope is the data structure for messages. It wraps the generic message payload with attributes.
 type MessageEnvelope struct {
-	// ReceivedTopic is the topic that the message was receive on.
+	// ReceivedTopic is the topic that the message was received on.
 	ReceivedTopic string
-	// CorrelationID is an object id to identify the envelop
+	// CorrelationID is an object id to identify the envelope.
 	CorrelationID string
+	// ApiVersion shows the API version in message envelope.
+	ApiVersion string
+	// RequestID is an object id to identify the request.
+	RequestID string
+	// ErrorCode provides the indication of error. '0' indicates no error, '1' indicates error.
+	// Additional codes may be added in the future. If non-0, the payload will contain the error.
+	ErrorCode int
 	// Payload is byte representation of the data being transferred.
 	Payload []byte
 	// ContentType is the marshaled type of payload, i.e. application/json, application/xml, application/cbor, etc
 	ContentType string
+	// QueryParams is optionally provided key/value pairs.
+	QueryParams map[string]string
 }
 
 // NewMessageEnvelope creates a new MessageEnvelope for the specified payload with attributes from the specified context
 func NewMessageEnvelope(payload []byte, ctx context.Context) MessageEnvelope {
 	envelope := MessageEnvelope{
-		CorrelationID: fromContext(ctx, correlationId),
-		ContentType:   fromContext(ctx, contentType),
+		ApiVersion:    ApiVersion,
+		CorrelationID: fromContext(ctx, CorrelationID),
+		ContentType:   fromContext(ctx, ContentType),
 		Payload:       payload,
+		QueryParams:   make(map[string]string),
 	}
 
 	return envelope
+}
+
+// NewMessageEnvelopeForRequest creates a new MessageEnvelope for sending request to EdgeX via internal
+// MessageBus to target Device Service. Used when request is from internal App Service via command client.
+func NewMessageEnvelopeForRequest(payload []byte, queryParams map[string]string) MessageEnvelope {
+	envelope := MessageEnvelope{
+		CorrelationID: uuid.NewString(),
+		ApiVersion:    ApiVersion,
+		RequestID:     uuid.NewString(),
+		ErrorCode:     0,
+		Payload:       payload,
+		ContentType:   ContentTypeJSON,
+		QueryParams:   make(map[string]string),
+	}
+
+	if len(queryParams) > 0 {
+		envelope.QueryParams = queryParams
+	}
+
+	return envelope
+}
+
+// NewMessageEnvelopeForResponse creates a new MessageEnvelope for sending response from Device Service back to Core Command.
+func NewMessageEnvelopeForResponse(payload []byte, requestId string, correlationId string, contentType string) (MessageEnvelope, error) {
+	if _, err := uuid.Parse(requestId); err != nil {
+		return MessageEnvelope{}, err
+	}
+	if _, err := uuid.Parse(correlationId); err != nil {
+		return MessageEnvelope{}, err
+	}
+	if contentType == "" {
+		return MessageEnvelope{}, errors.New("ContentType is empty")
+	}
+
+	envelope := MessageEnvelope{
+		CorrelationID: correlationId,
+		ApiVersion:    ApiVersion,
+		RequestID:     requestId,
+		ErrorCode:     0,
+		Payload:       payload,
+		ContentType:   contentType,
+		QueryParams:   make(map[string]string),
+	}
+
+	return envelope, nil
+}
+
+// NewMessageEnvelopeFromJSON creates a new MessageEnvelope by decoding the message payload
+// received from external MQTT in order to send request via internal MessageBus.
+func NewMessageEnvelopeFromJSON(message []byte) (MessageEnvelope, error) {
+	var envelope MessageEnvelope
+	err := json.Unmarshal(message, &envelope)
+	if err != nil {
+		return MessageEnvelope{}, err
+	}
+
+	if envelope.ApiVersion != ApiVersion {
+		return MessageEnvelope{}, errors.New("api version 'v2' is required")
+	}
+
+	if _, err = uuid.Parse(envelope.RequestID); err != nil {
+		return MessageEnvelope{}, fmt.Errorf("error parsing RequestID: %s", err.Error())
+	}
+
+	if _, err = uuid.Parse(envelope.CorrelationID); err != nil {
+		if envelope.CorrelationID != "" {
+			return MessageEnvelope{}, fmt.Errorf("error parsing CorrelationID: %s", err.Error())
+		}
+
+		envelope.CorrelationID = uuid.NewString()
+	}
+
+	if envelope.ContentType != ContentTypeJSON {
+		return envelope, errors.New("ContentType is not application/json")
+	}
+
+	if envelope.QueryParams == nil {
+		envelope.QueryParams = make(map[string]string)
+	}
+
+	return envelope, nil
+}
+
+// NewMessageEnvelopeWithError creates a new MessageEnvelope with ErrorCode set to 1 indicating there's error
+// and the payload contains message string about the error.
+func NewMessageEnvelopeWithError(requestId string, errorMessage string) MessageEnvelope {
+	return MessageEnvelope{
+		CorrelationID: uuid.NewString(),
+		ApiVersion:    ApiVersion,
+		RequestID:     requestId,
+		ErrorCode:     1,
+		Payload:       []byte(errorMessage),
+		ContentType:   ContentTypeText,
+		QueryParams:   make(map[string]string),
+	}
 }
 
 func fromContext(ctx context.Context, key string) string {

--- a/pkg/types/message_envelope_test.go
+++ b/pkg/types/message_envelope_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2022 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,36 +19,185 @@ package types
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testRequestId     = "3ab0e022-464b-4bfe-bf7f-b0154093ddad"
+	testCorrelationId = "fa1def22-96de-4d44-8811-00333438c8e3"
+	testPayload       = `{"data" : "myData"}`
 )
 
 func TestNewMessageEnvelope(t *testing.T) {
-
-	expectedCorrelationId := "this is my correlation id"
-	expectedContentType := "application/json"
-	expectedPayload := `{"data" : "myData"}`
-
 	// lint:ignore SA1029 legacy
 	// nolint:staticcheck // See golangci-lint #741
-	ctx := context.WithValue(context.Background(), correlationId, expectedCorrelationId)
+	ctx := context.WithValue(context.Background(), CorrelationID, testCorrelationId)
 	// lint:ignore SA1029 legacy
 	// nolint:staticcheck // See golangci-lint #741
-	ctx = context.WithValue(ctx, contentType, expectedContentType)
+	ctx = context.WithValue(ctx, ContentType, ContentTypeJSON)
 
-	envelope := NewMessageEnvelope([]byte(expectedPayload), ctx)
+	envelope := NewMessageEnvelope([]byte(testPayload), ctx)
 
-	assert.Equal(t, expectedCorrelationId, envelope.CorrelationID)
-	assert.Equal(t, expectedContentType, envelope.ContentType)
-	assert.Equal(t, expectedPayload, string(envelope.Payload))
+	assert.Equal(t, ApiVersion, envelope.ApiVersion)
+	assert.Equal(t, testCorrelationId, envelope.CorrelationID)
+	assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+	assert.Equal(t, testPayload, string(envelope.Payload))
+	assert.Empty(t, envelope.QueryParams)
 }
 
 func TestNewMessageEnvelopeEmpty(t *testing.T) {
-
 	envelope := NewMessageEnvelope([]byte{}, context.Background())
 
+	assert.Equal(t, ApiVersion, envelope.ApiVersion)
+	assert.Empty(t, envelope.RequestID)
 	assert.Empty(t, envelope.CorrelationID)
 	assert.Empty(t, envelope.ContentType)
 	assert.Empty(t, envelope.Payload)
+	assert.Zero(t, envelope.ErrorCode)
+	assert.Empty(t, envelope.QueryParams)
+}
+
+func TestNewMessageEnvelopeForRequest(t *testing.T) {
+	expectedQueryParams := map[string]string{"foo": "bar"}
+	emptyQueryParams := map[string]string{}
+
+	tests := []struct {
+		name          string
+		queryParams   map[string]string
+		expectedEmpty bool
+	}{
+		{"valid - normal queryParams map", expectedQueryParams, false},
+		{"valid - empty queryParams map", emptyQueryParams, true},
+		{"valid - nil queryParams", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelope := NewMessageEnvelopeForRequest([]byte(testPayload), tt.queryParams)
+
+			assert.NotEmpty(t, envelope.RequestID)
+			assert.NotEmpty(t, envelope.CorrelationID)
+			assert.Equal(t, ApiVersion, envelope.ApiVersion)
+			assert.Equal(t, testPayload, string(envelope.Payload))
+			assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+			assert.Equal(t, 0, envelope.ErrorCode)
+			assert.NotNil(t, envelope.QueryParams)
+			if tt.expectedEmpty {
+				assert.Empty(t, envelope.QueryParams)
+				return
+			}
+
+			assert.Equal(t, expectedQueryParams, envelope.QueryParams)
+		})
+	}
+}
+
+func TestNewMessageEnvelopeForResponse(t *testing.T) {
+	invalidUUID := "123456"
+
+	tests := []struct {
+		name          string
+		correlationId string
+		requestId     string
+		contentType   string
+		expectedError bool
+	}{
+		{"valid", testCorrelationId, testRequestId, ContentTypeJSON, false},
+		{"invalid - CorrelationID is not in UUID format", invalidUUID, testRequestId, ContentTypeJSON, true},
+		{"invalid - invalid requestID is not in UUID format", testCorrelationId, invalidUUID, ContentTypeJSON, true},
+		{"invalid - ContentType is empty", testCorrelationId, testRequestId, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelope, err := NewMessageEnvelopeForResponse([]byte(testPayload), tt.requestId, tt.correlationId, tt.contentType)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, testRequestId, envelope.RequestID)
+			assert.Equal(t, testCorrelationId, envelope.CorrelationID)
+			assert.Equal(t, ApiVersion, envelope.ApiVersion)
+			assert.Equal(t, testPayload, string(envelope.Payload))
+			assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+			assert.Equal(t, 0, envelope.ErrorCode)
+			assert.NotNil(t, envelope.QueryParams)
+		})
+	}
+}
+
+func TestNewMessageEnvelopeFromJSON(t *testing.T) {
+	invalidUUID := "123456"
+	validEnvelope := testMessageEnvelope()
+	validNoCorrelationIDEnvelope := validEnvelope
+	validNoCorrelationIDEnvelope.CorrelationID = ""
+	invalidApiVersionEnvelope := validEnvelope
+	invalidApiVersionEnvelope.ApiVersion = "v1"
+	invalidRequestIDEnvelope := validEnvelope
+	invalidRequestIDEnvelope.RequestID = invalidUUID
+	invalidCorrelationIDEnvelope := validEnvelope
+	invalidCorrelationIDEnvelope.CorrelationID = invalidUUID
+	invalidContentTypeEnvelope := validEnvelope
+	invalidContentTypeEnvelope.ContentType = ""
+
+	tests := []struct {
+		name          string
+		envelope      MessageEnvelope
+		expectedError bool
+	}{
+		{"valid", validEnvelope, false},
+		{"valid - CorrelationID is not set", validNoCorrelationIDEnvelope, false},
+		{"invalid - API version not 'v2'", invalidApiVersionEnvelope, true},
+		{"invalid - RequestID is not UUID format", invalidRequestIDEnvelope, true},
+		{"invalid - CorrelationID is not UUID format", invalidCorrelationIDEnvelope, true},
+		{"invalid - ContentType is not application/json", invalidContentTypeEnvelope, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := json.Marshal(tt.envelope)
+			require.NoError(t, err)
+
+			envelope, err := NewMessageEnvelopeFromJSON(payload)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, testRequestId, envelope.RequestID)
+			assert.NotEmpty(t, testCorrelationId, envelope.CorrelationID)
+			assert.Equal(t, ApiVersion, envelope.ApiVersion)
+			assert.Equal(t, testPayload, string(envelope.Payload))
+			assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+			assert.Equal(t, 0, envelope.ErrorCode)
+			assert.NotNil(t, envelope.QueryParams)
+		})
+	}
+}
+
+func TestNewMessageEnvelopeWithError(t *testing.T) {
+	expectedPayload := `error: something failed`
+
+	envelope := NewMessageEnvelopeWithError(testRequestId, expectedPayload)
+
+	assert.NotEmpty(t, testCorrelationId, envelope.CorrelationID)
+	assert.Equal(t, ApiVersion, envelope.ApiVersion)
+	assert.Equal(t, testRequestId, envelope.RequestID)
+	assert.Equal(t, 1, envelope.ErrorCode)
+	assert.Equal(t, expectedPayload, string(envelope.Payload))
+	assert.Equal(t, ContentTypeText, envelope.ContentType)
+	assert.Empty(t, envelope.QueryParams)
+}
+
+func testMessageEnvelope() MessageEnvelope {
+	return MessageEnvelope{
+		CorrelationID: testCorrelationId,
+		ApiVersion:    ApiVersion,
+		RequestID:     testRequestId,
+		ErrorCode:     0,
+		Payload:       []byte(testPayload),
+		ContentType:   ContentTypeJSON,
+	}
 }


### PR DESCRIPTION
to support north-south messaging implementation

fix #160

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
Add new dependency: https://github.com/edgexfoundry/go-mod-core-contracts
to access the common constants in EdgeX