### PR TITLE
refactor!: Use bool types for command parameters to be more consistent

### DIFF
--- a/clients/command.go
+++ b/clients/command.go
@@ -168,12 +168,12 @@ func (c *CommandClient) DeviceCoreCommandsByDeviceName(ctx context.Context, devi
 	}
 }
 
-func (c *CommandClient) IssueGetCommandByName(ctx context.Context, deviceName string, commandName string, dsPushEvent string, dsReturnEvent string) (*responses.EventResponse, edgexErr.EdgeX) {
+func (c *CommandClient) IssueGetCommandByName(ctx context.Context, deviceName string, commandName string, dsPushEvent bool, dsReturnEvent bool) (*responses.EventResponse, edgexErr.EdgeX) {
 	if c.commandMessages == nil {
 		return nil, edgexErr.NewCommonEdgeX(edgexErr.KindServerError, "command request/response topics not provided", nil)
 	}
 
-	queryParams := map[string]string{common.PushEvent: dsPushEvent, common.ReturnEvent: dsReturnEvent}
+	queryParams := map[string]string{common.PushEvent: strconv.FormatBool(dsPushEvent), common.ReturnEvent: strconv.FormatBool(dsReturnEvent)}
 	return c.IssueGetCommandByNameWithQueryParams(ctx, deviceName, commandName, queryParams)
 }
 
@@ -207,7 +207,7 @@ func (c *CommandClient) IssueGetCommandByNameWithQueryParams(ctx context.Context
 
 			var res responses.EventResponse
 			returnEvent, ok := queryParams[common.ReturnEvent]
-			if ok && returnEvent == common.ValueNo {
+			if ok && returnEvent == common.ValueFalse {
 				res.ApiVersion = common.ApiVersion
 				res.RequestId = responseEnvelope.RequestID
 				res.StatusCode = http.StatusOK

--- a/clients/command_test.go
+++ b/clients/command_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -151,7 +152,11 @@ func TestCommandClient_IssueGetCommandByName(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		res, err := client.IssueGetCommandByName(context.Background(), testDeviceName, testCommandName, "no", "tes")
+		notPushEvent, err := strconv.ParseBool(common.ValueFalse)
+		require.NoError(t, err)
+		returnEvent, err := strconv.ParseBool(common.ValueTrue)
+		require.NoError(t, err)
+		res, err := client.IssueGetCommandByName(context.Background(), testDeviceName, testCommandName, notPushEvent, returnEvent)
 
 		require.NoError(t, err)
 		require.IsType(t, res, &responses.EventResponse{})

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3
 	github.com/go-redis/redis/v7 v7.3.0
 	github.com/google/uuid v1.3.0
 	github.com/nats-io/nats-server/v2 v2.9.9

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2 h1:tleTxhbBISfDNn596rU71n+GOy27dMIme+v8Vl0uhpw=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3 h1:Ia/y/w9w3SmXqIqJ+Vjmv6QrP49YJDpTY6262C1Jrzs=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=


### PR DESCRIPTION
BREAKING CHANGE: ds-pushevent and ds-returnevent to use bool true/false instead of yes/no

related: https://github.com/edgexfoundry/go-mod-core-contracts/pull/782

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/917

## Testing Instructions
<!-- How can the reviewers test your change? -->
build core-command and device-virtual docker images based on the changes and run docker-compose.yml
The following commands work as expected:

```
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=true
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=false
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=true
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=false
```

and the following commands return errors as expected:
```
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=yes
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=no
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=yes
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=no
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->