### PR TITLE
refactor!: Refactor Redis Pub/sub topic wild cards to match that of MQTT

### DIFF
--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -1,6 +1,7 @@
 /********************************************************************************
  *  Copyright 2020 Dell Inc.
  *  Copyright (c) 2021 Intel Corporation
+ *  Copyright (C) 2023 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +35,7 @@ const (
 	StandardTopicSeparator = "/"
 	RedisTopicSeparator    = "."
 	StandardWildcard       = "#"
+	SingleLevelWildcard    = "+"
 	RedisWildcard          = "*"
 )
 
@@ -250,18 +252,20 @@ func createRedisClient(
 
 func convertToRedisTopicScheme(topic string) string {
 	// Redis Pub/Sub uses "." for separator and "*" for wild cards.
-	// Since we have standardized on the MQTT style scheme or "/" & "#" we need to
+	// Since we have standardized on the MQTT style scheme of "/" & "#" & "+" we need to
 	// convert it to the Redis Pub/Sub scheme.
 	topic = strings.Replace(topic, StandardTopicSeparator, RedisTopicSeparator, -1)
 	topic = strings.Replace(topic, StandardWildcard, RedisWildcard, -1)
+	topic = strings.Replace(topic, SingleLevelWildcard, RedisWildcard, -1)
 
 	return topic
 }
 
 func convertFromRedisTopicScheme(topic string) string {
 	// Redis Pub/Sub uses "." for separator and "*" for wild cards.
-	// Since we have standardized on the MQTT style scheme or "/" & "#" we need to
+	// Since we have standardized on the MQTT style scheme of "/" & "#" & "+" we need to
 	// convert it from the Redis Pub/Sub scheme.
+	topic = strings.Replace(topic, RedisWildcard+RedisTopicSeparator, SingleLevelWildcard+StandardTopicSeparator, -1)
 	topic = strings.Replace(topic, RedisTopicSeparator, StandardTopicSeparator, -1)
 	topic = strings.Replace(topic, RedisWildcard, StandardWildcard, -1)
 


### PR DESCRIPTION
BREAKING CHANGE: implement the topic conversion between Redis Pub/sub wild card `*` and MQTT wild cards `+` for single level and `#` for multiple levels

close #166

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) update existing unit tests
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A, no related docs

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Update device-virtual system event topic to `edgex/system-events/core-metadata/device/+/device-virtual/#`
2. Build and run device-virtual
3. Receive system events correctly

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->