### PR TITLE
fix: Optimize Redis Unsubscribe so the subscriptions are closed and removed

### DIFF
--- a/internal/pkg/redis/client_integration_test.go
+++ b/internal/pkg/redis/client_integration_test.go
@@ -126,6 +126,10 @@ func TestRedisUnsubscribeIntegration(t *testing.T) {
 					println("Unsubscribing from topic: " + eventTopic)
 					err = client.Unsubscribe(eventTopic)
 					require.NoError(t, err)
+
+					time.Sleep(time.Second)
+					_, exists := client.existingTopics[eventTopic]
+					assert.False(t, exists)
 				}
 			}
 		}

--- a/internal/pkg/redis/client_test.go
+++ b/internal/pkg/redis/client_test.go
@@ -447,6 +447,7 @@ func TestClient_Unsubscribe(t *testing.T) {
 	creator := func(redisServerURL string, password string, tlsConfig *tls.Config) (RedisClient, error) {
 		redisMock := &redisMocks.RedisClient{}
 		redisMock.On("Subscribe", mock.Anything)
+		redisMock.On("Unsubscribe", mock.Anything)
 		redisMock.On("Receive", mock.Anything).After(time.Millisecond*100).Run(func(args mock.Arguments) {
 			topic := args.Get(0).(string)
 			waitMap[topic].Wait()
@@ -630,6 +631,10 @@ func (r *SubscriptionRedisClientMock) Send(string, types.MessageEnvelope) error 
 }
 
 func (r *SubscriptionRedisClientMock) Subscribe(_ string) {
+
+}
+
+func (r *SubscriptionRedisClientMock) Unsubscribe(_ string) {
 
 }
 

--- a/internal/pkg/redis/goredis.go
+++ b/internal/pkg/redis/goredis.go
@@ -75,6 +75,20 @@ func (g *goRedisWrapper) Subscribe(topic string) {
 	g.getSubscription(topic)
 }
 
+// Unsubscribe closes the subscription in Redis and removes it.
+func (g *goRedisWrapper) Unsubscribe(topic string) {
+	g.subscriptionsMutex.Lock()
+	defer g.subscriptionsMutex.Unlock()
+
+	subscription := g.subscriptions[topic]
+	if subscription == nil {
+		return
+	}
+
+	_ = subscription.Close()
+	delete(g.subscriptions, topic)
+}
+
 // Receive retrieves the next message from the specified topic. This operation blocks indefinitely until a
 // message is received for the topic.
 func (g *goRedisWrapper) Receive(topic string) (*types.MessageEnvelope, error) {

--- a/internal/pkg/redis/mocks/RedisClient.go
+++ b/internal/pkg/redis/mocks/RedisClient.go
@@ -72,6 +72,11 @@ func (_m *RedisClient) Subscribe(topic string) {
 	_m.Called(topic)
 }
 
+// Unsubscribe provides a mock function with given fields: topic
+func (_m *RedisClient) Unsubscribe(topic string) {
+	_m.Called(topic)
+}
+
 type mockConstructorTestingTNewRedisClient interface {
 	mock.TestingT
 	Cleanup(func())

--- a/internal/pkg/redis/types.go
+++ b/internal/pkg/redis/types.go
@@ -42,6 +42,8 @@ type RedisClientCreator func(redisServerURL string, password string, tlsConfig *
 type RedisClient interface {
 	// Subscribe creates the subscription in Redis
 	Subscribe(topic string)
+	// Unsubscribe closes the subscription in Redis and removes it.
+	Unsubscribe(topic string)
 	// Send sends a message to the specified topic, aka Publish.
 	Send(topic string, message types.MessageEnvelope) error
 	// Receive blocking operation which receives the next message for the specified subscribed topic


### PR DESCRIPTION
This should avoid too many open files in Redis.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Tested with Redis Integration tests as well as Core Metadata adding devices.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->