### PR TITLE
refactor: Add JSON attributes to MessageEnvelope fields

### DIFF
--- a/internal/pkg/nats/marshaller_test.go
+++ b/internal/pkg/nats/marshaller_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +52,9 @@ func TestJSONMarshaller(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	unmarshaled := types.MessageEnvelope{}
+	unmarshaled := types.MessageEnvelope{
+		QueryParams: make(map[string]string),
+	}
 
 	err = sut.Unmarshal(marshaled, &unmarshaled)
 
@@ -136,7 +139,7 @@ func sampleMessage(plSize int) types.MessageEnvelope {
 	return types.MessageEnvelope{
 		ReceivedTopic: uuid.NewString(),
 		CorrelationID: uuid.NewString(),
-		ApiVersion:    types.ApiVersion,
+		Versionable:   common.NewVersionable(),
 		RequestID:     uuid.NewString(),
 		ErrorCode:     0,
 		Payload:       pl,

--- a/pkg/types/message_envelope.go
+++ b/pkg/types/message_envelope.go
@@ -37,13 +37,13 @@ const (
 
 // MessageEnvelope is the data structure for messages. It wraps the generic message payload with attributes.
 type MessageEnvelope struct {
+	// ApiVersion (from Versionable) shows the API version for the message envelope.
 	common.Versionable
-	// RequestID is an object id to identify the request.
 	// ReceivedTopic is the topic that the message was received on.
 	ReceivedTopic string `json:"receivedTopic"`
 	// CorrelationID is an object id to identify the envelope.
 	CorrelationID string `json:"correlationID"`
-	// ApiVersion shows the API version in message envelope.
+	// RequestID is an object id to identify the request.
 	RequestID string `json:"requestID"`
 	// ErrorCode provides the indication of error. '0' indicates no error, '1' indicates error.
 	// Additional codes may be added in the future. If non-0, the payload will contain the error.

--- a/pkg/types/message_envelope.go
+++ b/pkg/types/message_envelope.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
 	"github.com/google/uuid"
 )
 
@@ -36,29 +37,29 @@ const (
 
 // MessageEnvelope is the data structure for messages. It wraps the generic message payload with attributes.
 type MessageEnvelope struct {
-	// ReceivedTopic is the topic that the message was received on.
-	ReceivedTopic string
-	// CorrelationID is an object id to identify the envelope.
-	CorrelationID string
-	// ApiVersion shows the API version in message envelope.
-	ApiVersion string
+	common.Versionable
 	// RequestID is an object id to identify the request.
-	RequestID string
+	// ReceivedTopic is the topic that the message was received on.
+	ReceivedTopic string `json:"receivedTopic"`
+	// CorrelationID is an object id to identify the envelope.
+	CorrelationID string `json:"correlationID"`
+	// ApiVersion shows the API version in message envelope.
+	RequestID string `json:"requestID"`
 	// ErrorCode provides the indication of error. '0' indicates no error, '1' indicates error.
 	// Additional codes may be added in the future. If non-0, the payload will contain the error.
-	ErrorCode int
+	ErrorCode int `json:"errorCode"`
 	// Payload is byte representation of the data being transferred.
-	Payload []byte
+	Payload []byte `json:"payload"`
 	// ContentType is the marshaled type of payload, i.e. application/json, application/xml, application/cbor, etc
-	ContentType string
+	ContentType string `json:"contentType"`
 	// QueryParams is optionally provided key/value pairs.
-	QueryParams map[string]string
+	QueryParams map[string]string `json:"queryParams,omitempty"`
 }
 
 // NewMessageEnvelope creates a new MessageEnvelope for the specified payload with attributes from the specified context
 func NewMessageEnvelope(payload []byte, ctx context.Context) MessageEnvelope {
 	envelope := MessageEnvelope{
-		ApiVersion:    ApiVersion,
+		Versionable:   common.NewVersionable(),
 		CorrelationID: fromContext(ctx, CorrelationID),
 		ContentType:   fromContext(ctx, ContentType),
 		Payload:       payload,
@@ -73,7 +74,7 @@ func NewMessageEnvelope(payload []byte, ctx context.Context) MessageEnvelope {
 func NewMessageEnvelopeForRequest(payload []byte, queryParams map[string]string) MessageEnvelope {
 	envelope := MessageEnvelope{
 		CorrelationID: uuid.NewString(),
-		ApiVersion:    ApiVersion,
+		Versionable:   common.NewVersionable(),
 		RequestID:     uuid.NewString(),
 		ErrorCode:     0,
 		Payload:       payload,
@@ -102,7 +103,7 @@ func NewMessageEnvelopeForResponse(payload []byte, requestId string, correlation
 
 	envelope := MessageEnvelope{
 		CorrelationID: correlationId,
-		ApiVersion:    ApiVersion,
+		Versionable:   common.NewVersionable(),
 		RequestID:     requestId,
 		ErrorCode:     0,
 		Payload:       payload,
@@ -154,7 +155,7 @@ func NewMessageEnvelopeFromJSON(message []byte) (MessageEnvelope, error) {
 func NewMessageEnvelopeWithError(requestId string, errorMessage string) MessageEnvelope {
 	return MessageEnvelope{
 		CorrelationID: uuid.NewString(),
-		ApiVersion:    ApiVersion,
+		Versionable:   common.NewVersionable(),
 		RequestID:     requestId,
 		ErrorCode:     1,
 		Payload:       []byte(errorMessage),

--- a/pkg/types/message_envelope_test.go
+++ b/pkg/types/message_envelope_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -191,10 +192,24 @@ func TestNewMessageEnvelopeWithError(t *testing.T) {
 	assert.Empty(t, envelope.QueryParams)
 }
 
+func TestMessageEnvelopeJSON(t *testing.T) {
+	expected := testMessageEnvelope()
+	expected.QueryParams = make(map[string]string)
+	expected.QueryParams["q1"] = "v1"
+
+	data, err := json.Marshal(expected)
+	require.NoError(t, err)
+
+	actual, err := NewMessageEnvelopeFromJSON(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, actual)
+}
+
 func testMessageEnvelope() MessageEnvelope {
 	return MessageEnvelope{
 		CorrelationID: testCorrelationId,
-		ApiVersion:    ApiVersion,
+		Versionable:   common.NewVersionable(),
 		RequestID:     testRequestId,
 		ErrorCode:     0,
 		Payload:       []byte(testPayload),


### PR DESCRIPTION
Not a breaking change as original thought.

closes #169

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **Unit Test suffice**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->