### PR TITLE
fix: assure redis correctly subscribe to topic before receiving

### DIFF
--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -154,7 +154,11 @@ func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error)
 			messageChannel := topic.Messages
 			var previousErr error
 
-			c.redisClient.Subscribe(topicName)
+			err := c.redisClient.Subscribe(topicName)
+			if err != nil {
+				messageErrors <- err
+				return
+			}
 
 			wg.Done()
 

--- a/internal/pkg/redis/client_test.go
+++ b/internal/pkg/redis/client_test.go
@@ -35,13 +35,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/edgexfoundry/go-mod-messaging/v3/internal/pkg"
 	redisMocks "github.com/edgexfoundry/go-mod-messaging/v3/internal/pkg/redis/mocks"
 	"github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var HostInfo = types.HostInfo{
@@ -454,7 +454,7 @@ func TestClient_Unsubscribe(t *testing.T) {
 	}
 	creator := func(redisServerURL string, password string, tlsConfig *tls.Config) (RedisClient, error) {
 		redisMock := &redisMocks.RedisClient{}
-		redisMock.On("Subscribe", mock.Anything)
+		redisMock.On("Subscribe", mock.Anything).Return(nil)
 		redisMock.On("Unsubscribe", mock.Anything).Run(func(args mock.Arguments) {
 			topic := args.Get(0).(string)
 			unsubscribeWaitMap[topic].Done()
@@ -615,8 +615,8 @@ func (r *SubscriptionRedisClientMock) Send(string, types.MessageEnvelope) error 
 
 }
 
-func (r *SubscriptionRedisClientMock) Subscribe(_ string) {
-
+func (r *SubscriptionRedisClientMock) Subscribe(_ string) error {
+	return nil
 }
 
 func (r *SubscriptionRedisClientMock) Unsubscribe(_ string) {

--- a/internal/pkg/redis/mocks/RedisClient.go
+++ b/internal/pkg/redis/mocks/RedisClient.go
@@ -68,8 +68,17 @@ func (_m *RedisClient) Send(topic string, message types.MessageEnvelope) error {
 }
 
 // Subscribe provides a mock function with given fields: topic
-func (_m *RedisClient) Subscribe(topic string) {
-	_m.Called(topic)
+func (_m *RedisClient) Subscribe(topic string) error {
+	ret := _m.Called(topic)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(topic)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Unsubscribe provides a mock function with given fields: topic

--- a/internal/pkg/redis/types.go
+++ b/internal/pkg/redis/types.go
@@ -1,6 +1,7 @@
 /********************************************************************************
  *  Copyright 2020 Dell Inc.
  *  Copyright (c) 2021 Intel Corporation
+ *  Copyright (c) 2023 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,7 +42,7 @@ type RedisClientCreator func(redisServerURL string, password string, tlsConfig *
 // complex to test the operations without requiring a running Redis server.
 type RedisClient interface {
 	// Subscribe creates the subscription in Redis
-	Subscribe(topic string)
+	Subscribe(topic string) error
 	// Unsubscribe closes the subscription in Redis and removes it.
 	Unsubscribe(topic string)
 	// Send sends a message to the specified topic, aka Publish.


### PR DESCRIPTION
check client subscribes to topic successfully by examining if the first received message is subscribe confirmation message.

reference:
- https://github.com/redis/go-redis/issues/575#issuecomment-311994859
- https://redis.io/commands/psubscribe/#return

closes #227

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->