### PR TITLE
feat!: update API version to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.35
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.36
 	github.com/go-redis/redis/v7 v7.3.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.35 h1:XQgLXhpZ03JJAz4BvH371jQvFmiWcRI9wS90rE/PtS8=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.35/go.mod h1:1YS2J5NfPCd7TYBk0alu+RR5EBzBb+bnG0KF1qNRQYY=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.36 h1:zcdA7YbOHZyuP2Yzk9h8R/S7vrTgVJ7uv8vgqv8SjaE=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.36/go.mod h1:1YS2J5NfPCd7TYBk0alu+RR5EBzBb+bnG0KF1qNRQYY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=

--- a/internal/pkg/nats/marshaller_test.go
+++ b/internal/pkg/nats/marshaller_test.go
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2022 One Track Consulting
-// Copyright (c) 2022 IOTech Ltd
+// Copyright (c) 2022-2023 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -98,7 +99,7 @@ func TestNATSMarshaller(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, marshaled.Header.Get(correlationIDHeader))
 			assert.NotEmpty(t, marshaled.Header.Get(requestIDHeader))
-			assert.Equal(t, types.ApiVersion, marshaled.Header.Get(apiVersionHeader))
+			assert.Equal(t, common.ApiVersion, marshaled.Header.Get(apiVersionHeader))
 			assert.Equal(t, "0", marshaled.Header.Get(errorCodeHeader))
 			if tt.emptyQueryParams {
 				assert.Empty(t, marshaled.Header.Get(queryParamsHeader))
@@ -139,7 +140,7 @@ func sampleMessage(plSize int) types.MessageEnvelope {
 	return types.MessageEnvelope{
 		ReceivedTopic: uuid.NewString(),
 		CorrelationID: uuid.NewString(),
-		Versionable:   common.NewVersionable(),
+		Versionable:   commonDTO.NewVersionable(),
 		RequestID:     uuid.NewString(),
 		ErrorCode:     0,
 		Payload:       pl,

--- a/pkg/types/message_envelope_test.go
+++ b/pkg/types/message_envelope_test.go
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2019 Intel Corporation
-// Copyright (c) 2022 IOTech Ltd
+// Copyright (c) 2022-2023 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,16 +37,16 @@ const (
 func TestNewMessageEnvelope(t *testing.T) {
 	// lint:ignore SA1029 legacy
 	// nolint:staticcheck // See golangci-lint #741
-	ctx := context.WithValue(context.Background(), CorrelationID, testCorrelationId)
+	ctx := context.WithValue(context.Background(), common.CorrelationHeader, testCorrelationId)
 	// lint:ignore SA1029 legacy
 	// nolint:staticcheck // See golangci-lint #741
-	ctx = context.WithValue(ctx, ContentType, ContentTypeJSON)
+	ctx = context.WithValue(ctx, common.ContentType, common.ContentTypeJSON)
 
 	envelope := NewMessageEnvelope([]byte(testPayload), ctx)
 
-	assert.Equal(t, ApiVersion, envelope.ApiVersion)
+	assert.Equal(t, common.ApiVersion, envelope.ApiVersion)
 	assert.Equal(t, testCorrelationId, envelope.CorrelationID)
-	assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+	assert.Equal(t, common.ContentTypeJSON, envelope.ContentType)
 	assert.Equal(t, testPayload, string(envelope.Payload))
 	assert.Empty(t, envelope.QueryParams)
 }
@@ -53,7 +54,7 @@ func TestNewMessageEnvelope(t *testing.T) {
 func TestNewMessageEnvelopeEmpty(t *testing.T) {
 	envelope := NewMessageEnvelope([]byte{}, context.Background())
 
-	assert.Equal(t, ApiVersion, envelope.ApiVersion)
+	assert.Equal(t, common.ApiVersion, envelope.ApiVersion)
 	assert.Empty(t, envelope.RequestID)
 	assert.Empty(t, envelope.CorrelationID)
 	assert.Empty(t, envelope.ContentType)
@@ -81,9 +82,9 @@ func TestNewMessageEnvelopeForRequest(t *testing.T) {
 
 			assert.NotEmpty(t, envelope.RequestID)
 			assert.NotEmpty(t, envelope.CorrelationID)
-			assert.Equal(t, ApiVersion, envelope.ApiVersion)
+			assert.Equal(t, common.ApiVersion, envelope.ApiVersion)
 			assert.Equal(t, testPayload, string(envelope.Payload))
-			assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+			assert.Equal(t, common.ContentTypeJSON, envelope.ContentType)
 			assert.Equal(t, 0, envelope.ErrorCode)
 			assert.NotNil(t, envelope.QueryParams)
 			if tt.expectedEmpty {
@@ -106,9 +107,9 @@ func TestNewMessageEnvelopeForResponse(t *testing.T) {
 		contentType   string
 		expectedError bool
 	}{
-		{"valid", testCorrelationId, testRequestId, ContentTypeJSON, false},
-		{"invalid - CorrelationID is not in UUID format", invalidUUID, testRequestId, ContentTypeJSON, true},
-		{"invalid - invalid requestID is not in UUID format", testCorrelationId, invalidUUID, ContentTypeJSON, true},
+		{"valid", testCorrelationId, testRequestId, common.ContentTypeJSON, false},
+		{"invalid - CorrelationID is not in UUID format", invalidUUID, testRequestId, common.ContentTypeJSON, true},
+		{"invalid - invalid requestID is not in UUID format", testCorrelationId, invalidUUID, common.ContentTypeJSON, true},
 		{"invalid - ContentType is empty", testCorrelationId, testRequestId, "", true},
 	}
 	for _, tt := range tests {
@@ -121,9 +122,9 @@ func TestNewMessageEnvelopeForResponse(t *testing.T) {
 
 			assert.Equal(t, testRequestId, envelope.RequestID)
 			assert.Equal(t, testCorrelationId, envelope.CorrelationID)
-			assert.Equal(t, ApiVersion, envelope.ApiVersion)
+			assert.Equal(t, common.ApiVersion, envelope.ApiVersion)
 			assert.Equal(t, testPayload, string(envelope.Payload))
-			assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+			assert.Equal(t, common.ContentTypeJSON, envelope.ContentType)
 			assert.Equal(t, 0, envelope.ErrorCode)
 			assert.NotNil(t, envelope.QueryParams)
 		})
@@ -169,9 +170,9 @@ func TestNewMessageEnvelopeFromJSON(t *testing.T) {
 
 			assert.Equal(t, testRequestId, envelope.RequestID)
 			assert.NotEmpty(t, testCorrelationId, envelope.CorrelationID)
-			assert.Equal(t, ApiVersion, envelope.ApiVersion)
+			assert.Equal(t, common.ApiVersion, envelope.ApiVersion)
 			assert.Equal(t, testPayload, string(envelope.Payload))
-			assert.Equal(t, ContentTypeJSON, envelope.ContentType)
+			assert.Equal(t, common.ContentTypeJSON, envelope.ContentType)
 			assert.Equal(t, 0, envelope.ErrorCode)
 			assert.NotNil(t, envelope.QueryParams)
 		})
@@ -184,11 +185,11 @@ func TestNewMessageEnvelopeWithError(t *testing.T) {
 	envelope := NewMessageEnvelopeWithError(testRequestId, expectedPayload)
 
 	assert.NotEmpty(t, testCorrelationId, envelope.CorrelationID)
-	assert.Equal(t, ApiVersion, envelope.ApiVersion)
+	assert.Equal(t, common.ApiVersion, envelope.ApiVersion)
 	assert.Equal(t, testRequestId, envelope.RequestID)
 	assert.Equal(t, 1, envelope.ErrorCode)
 	assert.Equal(t, expectedPayload, string(envelope.Payload))
-	assert.Equal(t, ContentTypeText, envelope.ContentType)
+	assert.Equal(t, common.ContentTypeText, envelope.ContentType)
 	assert.Empty(t, envelope.QueryParams)
 }
 
@@ -209,10 +210,10 @@ func TestMessageEnvelopeJSON(t *testing.T) {
 func testMessageEnvelope() MessageEnvelope {
 	return MessageEnvelope{
 		CorrelationID: testCorrelationId,
-		Versionable:   common.NewVersionable(),
+		Versionable:   commonDTO.NewVersionable(),
 		RequestID:     testRequestId,
 		ErrorCode:     0,
 		Payload:       []byte(testPayload),
-		ContentType:   ContentTypeJSON,
+		ContentType:   common.ContentTypeJSON,
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: apiVersion in MessageEnvelope is changed to v3

also reuse common constants in go-mod-core-contracts.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Build and run core-command and device-virtual from this branch
2. Verify `apiVersion: v3` is required in the MessageEnvelope

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->