### PR TITLE
fix: (WIP) Resolve hang issue when Redis Subscribe fails

### DIFF
--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -155,13 +155,11 @@ func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error)
 			var previousErr error
 
 			err := c.redisClient.Subscribe(topicName)
+			wg.Done()
 			if err != nil {
 				messageErrors <- err
-				wg.Done()
 				return
 			}
-
-			wg.Done()
 
 			for {
 

--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -157,6 +157,7 @@ func (c Client) Subscribe(topics []types.TopicChannel, messageErrors chan error)
 			err := c.redisClient.Subscribe(topicName)
 			if err != nil {
 				messageErrors <- err
+				wg.Done()
 				return
 			}
 


### PR DESCRIPTION
fixes #246

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Modify Device simple to have buffered channels for all channels use in subscribe
Build SDK Device Simple using this branch
Run Device Simple with just `-cp`
Verify service no longer hangs.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->