### PR TITLE
feat: Encode MessageBus topic path

### DIFF
--- a/clients/command_test.go
+++ b/clients/command_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 IOTech Ltd
+// Copyright (C) 2022-2024 IOTech Ltd
 // Copyright (c) 2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -263,7 +263,7 @@ func getCommandClientWithMockMessaging(t *testing.T, expectedResponse *types.Mes
 	mockMessageClient := &mocks.MessageClient{}
 	mockMessageClient.On("Request", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedResponse, expectedRequestError)
 
-	client := NewCommandClient(mockMessageClient, "edgex", 10*time.Second)
+	client := NewCommandClientWithNameFieldEscape(mockMessageClient, "edgex", 10*time.Second)
 
 	return client
 }


### PR DESCRIPTION
Add enableNameFieldEscape parameter to CommandClient and encode MessageBus topic path

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-messaging/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **not impact**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- Run unit test
- Test the client with core command

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->