### PR TITLE
fix: Ensure Unsubscribe waits for operation completion using getTokenError

### DIFF
--- a/internal/pkg/mqtt/client.go
+++ b/internal/pkg/mqtt/client.go
@@ -201,8 +201,12 @@ func (mc *Client) Unsubscribe(topics ...string) error {
 	defer mc.subscriptionMutex.Unlock()
 
 	token := mc.mqttClient.Unsubscribe(topics...)
-	if token.Error() != nil {
-		return token.Error()
+
+	optionsReader := mc.mqttClient.OptionsReader()
+
+	err := getTokenError(token, optionsReader.WriteTimeout(), UnsubscribeOperation, "Failed to unsubscribe")
+	if err != nil {
+		return err
 	}
 
 	for _, topic := range topics {

--- a/internal/pkg/mqtt/errors.go
+++ b/internal/pkg/mqtt/errors.go
@@ -1,5 +1,6 @@
 /********************************************************************************
  *  Copyright 2020 Dell Inc.
+ *  Copyright (c) 2025 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,9 +21,10 @@ import (
 
 const (
 	// Different Client operations.
-	PublishOperation   = "Publish"
-	SubscribeOperation = "Subscribe"
-	ConnectOperation   = "Connect"
+	PublishOperation     = "Publish"
+	SubscribeOperation   = "Subscribe"
+	ConnectOperation     = "Connect"
+	UnsubscribeOperation = "Unsubscribe"
 )
 
 // TimeoutErr defines an error representing operations which have not completed and surpassed the allowed wait time.


### PR DESCRIPTION
fix: #420 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core-command with the go-mod-messaging module from this branch, and verify that sending command requests via message bus works properly.