### PR TITLE
fix: Remove redundant clearing of criticalOperations from WaitForCriticalOperations

### DIFF
--- a/internal/pkg/criticalops.go
+++ b/internal/pkg/criticalops.go
@@ -60,9 +60,6 @@ func (m *CriticalOperationManager) WaitForCriticalOperations(timeout time.Durati
 
 	select {
 	case <-done:
-		m.criticalOpsMutex.Lock()
-		defer m.criticalOpsMutex.Unlock()
-		clear(m.criticalOperations)
 		return true
 	case <-time.After(timeout):
 		return false


### PR DESCRIPTION
Since each registered critical operation removes itself from the map in RegisterCriticalOperation once finished, this clearing is redundant.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
