### PR TITLE
fix(command): use response topic prefix for all-command queries

### DIFF
--- a/clients/command.go
+++ b/clients/command.go
@@ -61,7 +61,7 @@ func (c *CommandClient) AllDeviceCoreCommands(_ context.Context, offset int, lim
 	requestEnvelope := types.NewMessageEnvelopeForRequest(nil, queryParams)
 
 	requestTopic := common.BuildTopic(c.baseTopic, common.CoreCommandQueryRequestPublishTopic, common.All)
-	responseEnvelope, err := c.messageBus.Request(requestEnvelope, common.CoreCommandServiceKey, requestTopic, c.timeout)
+	responseEnvelope, err := c.messageBus.Request(requestEnvelope, requestTopic, c.responseTopicPrefix, c.timeout)
 	if err != nil {
 		return responses.MultiDeviceCoreCommandsResponse{}, edgexErr.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/command_test.go
+++ b/clients/command_test.go
@@ -71,6 +71,26 @@ func TestCommandClient_AllDeviceCoreCommands(t *testing.T) {
 	}
 }
 
+func TestCommandClient_AllDeviceCoreCommandsUsesCommandQueryRequestTopicAndResponsePrefix(t *testing.T) {
+	responseDTO := responses.NewMultiDeviceCoreCommandsResponse(expectedRequestID, "", http.StatusOK, 0, nil)
+
+	responseEnvelope, err := types.NewMessageEnvelopeForResponse(responseDTO, expectedRequestID, expectedCorrelationID, common.ContentTypeJSON)
+	require.NoError(t, err)
+
+	timeout := 10 * time.Second
+	requestTopic := common.BuildTopic("edgex", common.CoreCommandQueryRequestPublishTopic, common.All)
+	responseTopicPrefix := common.BuildTopic("edgex", common.ResponseTopic, common.CoreCommandServiceKey)
+	messageClient := mocks.NewMessageClient(t)
+	messageClient.On("Request", mock.Anything, requestTopic, responseTopicPrefix, timeout).
+		Return(&responseEnvelope, nil).
+		Once()
+
+	client := NewCommandClientWithNameFieldEscape(messageClient, "edgex", timeout)
+	_, err = client.AllDeviceCoreCommands(context.Background(), 0, 20)
+
+	require.NoError(t, err)
+}
+
 func TestCommandClient_DeviceCoreCommandsByDeviceName(t *testing.T) {
 	responseDTO := responses.NewDeviceCoreCommandResponse(expectedRequestID, "", http.StatusOK, dtos.DeviceCoreCommand{})
 


### PR DESCRIPTION
## Description

Fixes `CommandClient.AllDeviceCoreCommands` so request/response messaging uses the command query request topic together with the configured response topic prefix.

Previously, the request passed `CoreCommandServiceKey` where the response topic prefix should be used. This updates the request call to match the other command query paths and adds a regression test covering the expected request topic and response prefix.

## PR Checklist

- [x] I am not introducing a breaking change
- [x] I am not introducing a new dependency
- [x] I have added unit tests for the new feature or bug fix
- [x] I have fully tested this new feature or bug fix
- [x] I have opened a PR for the related docs change (if not, why?)

No docs PR needed; this is an internal command client messaging fix.

## Testing Instructions

Run:

```sh
go test ./clients
```

Validated locally with:

```sh
env GOCACHE=/tmp/codex-go-build-cache go test ./clients
```

## New Dependency Instructions

Not applicable. No new dependencies were added.